### PR TITLE
change demuxer to be exclusive by default

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
@@ -19,6 +19,7 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.DemuxerNode
 import org.jitsi.nlj.transform.node.Node
 import org.jitsi.nlj.transform.node.ConditionalPacketPath
+import org.jitsi.nlj.transform.node.ExclusivePathDemuxer
 import org.jitsi.rtp.Packet
 
 
@@ -63,7 +64,7 @@ class PipelineBuilder {
     }
 
     fun demux(name: String, block: DemuxerNode.() -> Unit) {
-        val demuxer = DemuxerNode(name).apply(block)
+        val demuxer = ExclusivePathDemuxer(name).apply(block)
         addNode(demuxer)
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/DemuxerNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/DemuxerNode.kt
@@ -19,8 +19,8 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.NodeVisitor
 import kotlin.streams.toList
 
-class DemuxerNode(name: String) : Node("$name demuxer") {
-    private var transformPaths: MutableSet<ConditionalPacketPath> = mutableSetOf()
+abstract class DemuxerNode(name: String) : Node("$name demuxer") {
+    protected var transformPaths: MutableSet<ConditionalPacketPath> = mutableSetOf()
 
     fun addPacketPath(pp: ConditionalPacketPath) {
         transformPaths.add(pp)
@@ -38,15 +38,6 @@ class DemuxerNode(name: String) : Node("$name demuxer") {
     }
 
     override fun attach(node: Node?) = throw Exception()
-
-    override fun doProcessPackets(p: List<PacketInfo>) {
-        // Is this scheme always better? Or only when the list of
-        // packets is above a certain size?
-        transformPaths.forEach { conditionalPath ->
-            val pathPackets = p.filter { conditionalPath.predicate(it.packet) }
-            next(conditionalPath.path, pathPackets)
-        }
-    }
 
     override fun visit(visitor: NodeVisitor) {
         visitor.visit(this)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxer.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxer.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.transform.node
+
+import org.jitsi.nlj.PacketInfo
+
+/**
+ * Packets are passed only to the first path which accepts them
+ */
+class ExclusivePathDemuxer(name: String) : DemuxerNode(name) {
+    override fun doProcessPackets(p: List<PacketInfo>) {
+        p.forEach packets@ { packetInfo ->
+            transformPaths.forEach { conditionalPath ->
+                if (conditionalPath.predicate(packetInfo.packet)) {
+                    next(conditionalPath.path, listOf(packetInfo))
+                    return@packets
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.transform.node
+
+import io.kotlintest.IsolationMode
+import io.kotlintest.Spec
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.ShouldSpec
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.rtp.Packet
+import org.jitsi.rtp.RtpPacket
+import org.jitsi.rtp.rtcp.RtcpHeader
+import org.jitsi.rtp.rtcp.RtcpPacket
+import java.nio.ByteBuffer
+
+internal class ExclusivePathDemuxerTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    private class DummyHandler(name: String) : Node(name) {
+        var numReceived = 0
+        override fun doProcessPackets(p: List<PacketInfo>) {
+            numReceived += p.size
+        }
+    }
+
+    private class DummyRtcpPacket : RtcpPacket() {
+        override var header: RtcpHeader = RtcpHeader()
+        override val size: Int = 0
+        override fun clone(): Packet {
+            return DummyRtcpPacket()
+        }
+
+        override fun getBuffer(): ByteBuffer {
+            return ByteBuffer.allocate(0)
+        }
+    }
+
+    private val rtpPath = ConditionalPacketPath()
+    private val rtpHandler = DummyHandler("RTP")
+    private val rtcpPath = ConditionalPacketPath()
+    private val rtcpHandler = DummyHandler("RTCP")
+
+    private val demuxer = ExclusivePathDemuxer("test")
+
+    private val rtpPacket = PacketInfo(RtpPacket())
+    private val rtcpPacket = PacketInfo(DummyRtcpPacket())
+
+    override fun beforeSpec(spec: Spec) {
+        super.beforeSpec(spec)
+        rtpPath.name = "RTP"
+        rtpPath.predicate = { it is RtpPacket }
+        rtpPath.path = rtpHandler
+
+        rtcpPath.name = "RTCP"
+        rtcpPath.predicate = { it is RtcpPacket }
+        rtcpPath.path = rtcpHandler
+
+        demuxer.addPacketPath(rtpPath)
+        demuxer.addPacketPath(rtcpPath)
+    }
+
+    init {
+        "a packet which matches only one predicate" {
+            demuxer.processPackets(listOf(rtcpPacket))
+            should("only be demuxed to one path") {
+                rtpHandler.numReceived shouldBe 0
+                rtcpHandler.numReceived shouldBe 1
+            }
+        }
+        "a packet which matches more than one predicate" {
+            val rtpPath2 = ConditionalPacketPath()
+            val handler = DummyHandler("RTP 2")
+            rtpPath2.name = "RTP 2"
+            rtpPath2.predicate = { it is RtpPacket }
+            rtpPath2.path = handler
+            demuxer.addPacketPath(rtpPath2)
+            demuxer.processPackets(listOf(rtpPacket))
+            should("only be demuxed to one path") {
+                rtpHandler.numReceived shouldBe 1
+                rtcpHandler.numReceived shouldBe 0
+                handler.numReceived shouldBe 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
now we have an exclusivepathdemuxer which only forwards packets to the
first path that matches.  if we need a multi-path demuxer in the future
we can add it.