### PR TITLE
Adds a method to print a Node tree.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -119,7 +119,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
      * its place in the receive pipeline.  To support both keeping it in the same
      * place and allowing it to be re-assigned, we wrap it with this.
      */
-    private val rtpPacketHandlerWrapper = object : ConsumerNode("RTP packet handler wrapper") {
+    private val rtpPacketHandlerWrapper = object : ConsumerNode("Input termination (RTP)") {
         override fun consume(packetInfo: PacketInfo) {
             rtpPacketHandler?.processPacket(packetInfo)
         }
@@ -130,7 +130,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
      * its place in the receive pipeline.  To support both keeping it in the same
      * place and allowing it to be re-assigned, we wrap it with this.
      */
-    private val rtcpPacketHandlerWrapper = object : ConsumerNode("RTCP packet handler wrapper") {
+    private val rtcpPacketHandlerWrapper = object : ConsumerNode("Input termination (RTCP)") {
         override fun consume(packetInfo: PacketInfo) {
             rtcpPacketHandler?.processPacket(packetInfo)
         }
@@ -160,7 +160,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
             node(PacketParser("SRTP protocol parser") { SrtpProtocolPacket(it.getBuffer()) })
             demux("SRTP/SRTCP") {
                 packetPath {
-                    name = "SRTP path"
+                    name = "SRTP"
                     predicate = PacketPredicate { RtpProtocol.isRtp(it.getBuffer()) }
                     path = pipeline {
                         node(PacketParser("SRTP Parser") { SrtpPacket.create(it.getBuffer()) })
@@ -171,7 +171,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
                         node(statTracker)
                         demux("Media type") {
                             packetPath {
-                                name = "Audio path"
+                                name = "Audio"
                                 predicate = PacketPredicate { it is AudioRtpPacket }
                                 path = pipeline {
                                     node(audioLevelReader)
@@ -179,7 +179,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
                                 }
                             }
                             packetPath {
-                                name = "Video path"
+                                name = "Video"
                                 predicate = PacketPredicate { it is VideoRtpPacket }
                                 path = pipeline {
                                     node(RtxHandler())
@@ -195,7 +195,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
                     }
                 }
                 packetPath {
-                    name = "SRTCP path"
+                    name = "SRTCP"
                     predicate = PacketPredicate { RtpProtocol.isRtcp(it.getBuffer()) }
                     path = pipeline {
                         var prevRtcpPacket: Packet? = null

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -109,7 +109,7 @@ class RtpSenderImpl(
     )
     private val nackHandler: NackHandler
 
-    private val outputPipelineTerminationNode = object : ConsumerNode("Output pipeline termination node") {
+    private val outputPipelineTerminationNode = object : ConsumerNode("Output termination") {
         override fun consume(packetInfo: PacketInfo) {
             if (packetInfo.timeline.totalDelay() > Duration.ofMillis(100)) {
                 logger.cerror { "Packet took >100ms to get through bridge:\n${packetInfo.timeline}"}

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -105,6 +105,22 @@ abstract class Node(var name: String
             nextNode?.processPacket(packetInfo)
         }
     }
+
+    open fun printTree(): MutableList<String> {
+        val childTree = nextNode?.printTree() ?: return mutableListOf("[$name]")
+
+        val ourTree = mutableListOf<String>()
+        val ourName = "[$name] -> "
+        val padding = "".padStart(ourName.length)
+
+        var first = true
+        childTree.forEach {
+            ourTree.add((if (first) ourName else padding) + it)
+            first = false
+        }
+
+        return ourTree
+    }
 }
 
 /**
@@ -360,6 +376,35 @@ abstract class DemuxerNode(name: String) : StatsKeepingNode("$name demuxer") {
         superStats.addStat(demuxerBlock.name, demuxerBlock)
 
         return superStats
+    }
+
+    override fun printTree(): MutableList<String> {
+        val ourTree = mutableListOf<String>()
+        val ourName = "[$name] "
+        val paddingPre = "".padStart(ourName.length)
+
+        var firstChild = true
+        transformPaths.forEach {path ->
+            var firstString = true
+            val pathName = "-(${path.name})-> "
+            val paddingPost = "".padStart(pathName.length)
+
+            path.path.printTree().forEach {
+                val line: String
+                if (firstChild && firstString) {
+                    line = "$ourName-$pathName"
+                } else if (firstString) {
+                    line = "$paddingPre-$pathName"
+                } else {
+                    line = "$paddingPre|$paddingPost"
+                }
+
+                ourTree.add(line + it)
+                firstString = false
+            }
+            firstChild = false
+        }
+        return ourTree
     }
 }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
@@ -19,7 +19,7 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.util.PacketCache
 import org.jitsi.rtp.rtp.RtpPacket
 
-class PacketCacher : ObserverNode("Packet cache") {
+class PacketCacher : ObserverNode("Cache") {
     private val packetCache = PacketCache()
 
     override fun observe(packetInfo: PacketInfo) {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap
  * look like their original packets.
  * https://tools.ietf.org/html/rfc4588
  */
-class RtxHandler : TransformerNode("RTX handler") {
+class RtxHandler : TransformerNode("RTX") {
     private var numPaddingPacketsReceived = 0
     private var numRtxPacketsReceived = 0
     /**

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
@@ -30,7 +30,7 @@ import org.jitsi_modified.impl.neomedia.rtp.MediaStreamTrackDesc
  * individual encoding (that is, each forwardable stream taking into account spatial and temporal scalability) and
  * tags the [VideoRtpPacket] with a snapshot of the current estimated bitrate for the encoding to which it belongs
  */
-class VideoBitrateCalculator : ObserverNode("Video bitrate calculator") {
+class VideoBitrateCalculator : ObserverNode("Bitrate calculator") {
     private var mediaStreamTrackDescs: Array<MediaStreamTrackDesc> = arrayOf()
 
     override fun observe(packetInfo: PacketInfo) {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Parse video packets at a codec level and set appropriate meta-information
  */
-class VideoParser : TransformerNode("Video parser") {
+class VideoParser : TransformerNode("VideoParser") {
     private val payloadTypes: MutableMap<Byte, PayloadType> = ConcurrentHashMap()
     private var rtpEncodings: List<RTPEncodingDesc> = ArrayList()
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -28,7 +28,7 @@ import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.service.neomedia.RTPExtension
 import unsigned.toUInt
 
-class AbsSendTime : TransformerNode("Absolute send time") {
+class AbsSendTime : TransformerNode("AbsSendTime") {
     private val absSendTimeEngine = AbsSendTimeEngine()
 
     override fun transform(packetInfo: PacketInfo): PacketInfo? {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -20,7 +20,7 @@ import org.jitsi.nlj.transform.node.ObserverNode
 import org.jitsi.rtp.rtp.RtpPacket
 import java.util.concurrent.ConcurrentHashMap
 
-class OutgoingStatisticsTracker : ObserverNode("Outgoing statistics tracker") {
+class OutgoingStatisticsTracker : ObserverNode("Outgoing Stats") {
     private val streamStats: MutableMap<Long, OutgoingStreamStatistics> = ConcurrentHashMap()
 
     override fun observe(packetInfo: PacketInfo) {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SrtpTransformerEncryptNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SrtpTransformerEncryptNode.kt
@@ -22,7 +22,7 @@ import org.jitsi.nlj.util.cerror
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi_modified.impl.neomedia.transform.SinglePacketTransformer
 
-class SrtpTransformerEncryptNode : AbstractSrtpTransformerNode("SRTP Encrypt wrapper") {
+class SrtpTransformerEncryptNode : AbstractSrtpTransformerNode("SRTP Encrypt") {
     private var numEncryptFailures = 0
     override fun doTransform(pkts: List<PacketInfo>, transformer: SinglePacketTransformer): List<PacketInfo> {
         val outPackets = mutableListOf<PacketInfo>()

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -30,7 +30,7 @@ import unsigned.toUInt
 
 class TccSeqNumTagger(
     private val transportCcEngine: TransportCCEngine? = null
-) : TransformerNode("TCC sequence number tagger") {
+) : TransformerNode("TCC tagger") {
     private var currTccSeqNum: Int = 1
     private var tccExtensionId: Int? = null
 


### PR DESCRIPTION
I'm not actually sure we want this in master (ideally it would be a NodeVisitor, but it didn't easily fit), I used it for debugging.

```
[SRTP protocol parser] -> [SRTP/SRTCP demuxer] --(SRTP)-> [SRTP Parser] -> [RTP payload type filter] -> [TCC generator] -> [SRTP decrypt wrapper] -> [Media type parser] -> [Incoming statistics tracker] -> [Media type demuxer] --(Audio)-> [Audio level reader] -> [Input termination (RTP)]
                                               |                                                                                                                                                                                  --(Video)-> [RTX] -> [Padding termination] -> [VideoParser] -> [Vp8 parser] -> [Bitrate calculator] -> [Retransmission requester] -> [Input termination (RTP)]
                                               --(SRTCP)-> [SRTCP parser] -> [SRTCP decrypt] -> [RTCP pre-parse cache 1042818977] -> [Compound RTCP splitter] -> [RTCP termination] -> [Input termination (RTCP)]
```