### PR TITLE
generalize methods around a protocolstack as well as its 'sender' and

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -20,6 +20,7 @@ import org.bouncycastle.crypto.tls.DTLSTransport
 import org.bouncycastle.crypto.tls.DatagramTransport
 import org.bouncycastle.crypto.tls.TlsContext
 import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.protocol.ProtocolStack
 import org.jitsi.nlj.util.BufferPool
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.getLogger
@@ -56,7 +57,7 @@ import java.util.concurrent.TimeUnit
  *  dtlsStack.sendDtlsAppData(dtlsAppPacket)
  *
  */
-abstract class DtlsStack : DatagramTransport {
+abstract class DtlsStack : ProtocolStack, DatagramTransport {
     companion object {
         /**
          * Because generating the certificate can be expensive, we generate a single
@@ -104,7 +105,11 @@ abstract class DtlsStack : DatagramTransport {
      */
     private val incomingProtocolData = LinkedBlockingQueue<PacketInfo>()
     // TODO convert to single packet?
-    var onOutgoingProtocolData: (List<PacketInfo>) -> Unit = {}
+    private var onOutgoingProtocolData: (List<PacketInfo>) -> Unit = {}
+
+    override fun onOutgoingProtocolData(handler: (List<PacketInfo>) -> Unit) {
+        onOutgoingProtocolData = handler
+    }
 
     /**
      * The negotiated DTLS transport.  This is used to read and write DTLS app data.
@@ -121,12 +126,7 @@ abstract class DtlsStack : DatagramTransport {
     }
     protected var handshakeCompleteHandler: (TlsContext) -> Unit = {}
 
-    /**
-     * Process incoming DTLS packets from the network by passing them into the stack.  All received DTLS packets should
-     * be sent to the stack via this method.  Returns any DTLS app packets which were processed by the stack as part
-     * of this call.
-     */
-    fun processIncomingDtlsPackets(packetInfo: PacketInfo): List<PacketInfo> {
+    override fun processIncomingProtocolData(packetInfo: PacketInfo): List<PacketInfo> {
         incomingProtocolData.add(packetInfo)
         var bytesReceived: Int
         val outPackets = mutableListOf<PacketInfo>()
@@ -142,7 +142,7 @@ abstract class DtlsStack : DatagramTransport {
         return outPackets
     }
 
-    fun sendDtlsAppData(packetInfo: PacketInfo) {
+    override fun sendApplicationData(packetInfo: PacketInfo) {
         dtlsTransport?.send(packetInfo.packet.buffer, packetInfo.packet.offset, packetInfo.packet.length)
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/protocol/ProtocolStack.kt
+++ b/src/main/kotlin/org/jitsi/nlj/protocol/ProtocolStack.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.protocol
+
+import org.jitsi.nlj.PacketInfo
+
+/**
+ * Defines the input and output methods of a modeled [ProtocolStack].  There are 3 use cases modeled here:
+ *
+ * 1) A caller wants to send application data out 'over' a certain protocol:
+ *     A caller may use [ProtocolStack#sendApplicationData] to send data out over this protocol.  The implementing stack
+ *     is responsible for whatever encapsulation, etc. is necessary to send out the given application
+ *     data over that protocol
+ * 2) A stack wants to send data out to the network.  This data could be encapsulated application data
+ *     (sent via use case #1 above) or it could be protocol-specific packets used for something like
+ *     negotiation) and prompted by an incoming protocol negotiation packet, or even something like
+ *     a protocol-specific keepalive packet driven by a timer.
+ * 3) A packet has been received from the network that is determined to be of this protocol.  It is unknown
+ *     whether this data is protocol data (e.g.  for negotiation) or application data.  It is
+ *     fed into this [ProtocolStack] via [ProtocolStack#processIncomingProtocolData].  If the data was application data
+ *     that has been 'unwrapped' and should continue on, that data should be returned as a result of
+ *     [ProtocolStack#processIncomingProtocolData]
+ */
+interface ProtocolStack {
+    /**
+     * Send application data, wrapped within the packet in [packetInfo], out
+     * through this protocol stack and to the network.
+     *
+     * This is used when sending application data 'over' a certain protocol, and implies
+     * the stack will wrap the given application data in some manner specific to that
+     * protocol.
+     */
+    fun sendApplicationData(packetInfo: PacketInfo)
+
+    /**
+     * Install a handler to be invoked whenever this [ProtocolStack] has data
+     * it wants to send out to the network.  This data could be application
+     * data or protocol-specific data (e.g. packets used in negotiation or keepalives,
+     * etc.; basically data not explicitly sent out by the user via [sendApplicationData])
+     */
+    fun onOutgoingProtocolData(handler: (List<PacketInfo>) -> Unit)
+
+    /**
+     * Notify this [ProtocolStack] that incoming data, which has been determined to
+     * belong to this protocol, has been received from the network.  Returns
+     * potentially multiple [PacketInfo] packets representing protocol application
+     * packets which have been processed by the stack.
+     */
+    fun processIncomingProtocolData(packetInfo: PacketInfo): List<PacketInfo>
+}

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright @ 2018 Atlassian Pty Ltd
+ * Copyright @ 2018 - present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.jitsi.nlj.transform.node.incoming
 
 import org.jitsi.nlj.PacketInfo
-import org.jitsi.nlj.dtls.DtlsStack
+import org.jitsi.nlj.protocol.ProtocolStack
 import org.jitsi.nlj.transform.node.MultipleOutputTransformerNode
-import org.jitsi.nlj.util.cdebug
 
-/**
- * [DtlsReceiverNode] bridges a chain of modules to a DTLS's transport
- * (used by the bouncycastle stack).  Receives incoming DTLS data, passes it
- * to the DTLS stack and forwards any DTLS app packets
- */
-class DtlsReceiver(
-        private val dtlsStack: DtlsStack
-) : MultipleOutputTransformerNode("DTLS Receiver") {
+class ProtocolReceiver @JvmOverloads constructor(
+    private val stack: ProtocolStack,
+    name: String = stack::class.toString()
+) : MultipleOutputTransformerNode(name) {
+
     override fun transform(packetInfo: PacketInfo): List<PacketInfo> {
-        logger.cdebug { "DTLS receiver processing incoming DTLS packets" }
-        // TODO: we may be leaking packets here (failing to return them to the pool)
-        return dtlsStack.processIncomingDtlsPackets(packetInfo)
+        return stack.processIncomingProtocolData(packetInfo)
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright @ 2018 Atlassian Pty Ltd
+ * Copyright @ 2018 - present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.jitsi.nlj.transform.node.outgoing
 
 import org.jitsi.nlj.PacketInfo
-import org.jitsi.nlj.dtls.DtlsStack
+import org.jitsi.nlj.protocol.ProtocolStack
 import org.jitsi.nlj.transform.node.TransformerNode
 
-/**
- * A Node to handle the output of the sctp stack to bridge it back
- * into a pipeline.  This acts as the send half of the 'DatagramTransport'
- * (so it handles already encrypted DTLS packets).
- */
-class DtlsSender(
-    private val dtlsStack: DtlsStack
-) : TransformerNode("DTLS sender") {
+open class ProtocolSender @JvmOverloads constructor(
+    private val stack: ProtocolStack,
+    name: String = stack::class.toString()
+) : TransformerNode(name) {
+
     init {
-        dtlsStack.onOutgoingProtocolData =  ::next
+        stack.onOutgoingProtocolData(::next)
     }
 
     override fun transform(packetInfo: PacketInfo): PacketInfo? {
-        // Pass the packet into the stack.  When the stack is done processing it and packets are
-        // ready to be sent, it will invoke the onOutgoingProtocolData handler above
-        dtlsStack.sendDtlsAppData(packetInfo)
+        stack.sendApplicationData(packetInfo)
 
         return null
     }

--- a/src/test/kotlin/org/jitsi/nlj/transform/module/DtlsStackTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/module/DtlsStackTest.kt
@@ -40,8 +40,8 @@ import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.dtls.DtlsClientStack
 import org.jitsi.nlj.transform.node.ConsumerNode
-import org.jitsi.nlj.transform.node.incoming.DtlsReceiver
-import org.jitsi.nlj.transform.node.outgoing.DtlsSender
+import org.jitsi.nlj.transform.node.incoming.ProtocolReceiver
+import org.jitsi.nlj.transform.node.outgoing.ProtocolSender
 import org.jitsi.rtp.UnparsedPacket
 import java.math.BigInteger
 import java.security.KeyPair
@@ -146,8 +146,8 @@ internal class DtlsStackTest : ShouldSpec() {
 
     init {
         val dtls = DtlsClientStack()
-        val receiver = DtlsReceiver(dtls)
-        val sender = DtlsSender(dtls)
+        val receiver = ProtocolReceiver(dtls)
+        val sender = ProtocolSender(dtls)
 
         val serverTransport = FakeTransport()
         val dtlsServer = TlsServerImpl()
@@ -184,7 +184,7 @@ internal class DtlsStackTest : ShouldSpec() {
         // connect() below prevents the rest of the tests from running.
         dtls.connect()
         val message = "Hello, world"
-        dtls.sendDtlsAppData(PacketInfo(UnparsedPacket(message.toByteArray())))
+        dtls.sendApplicationData(PacketInfo(UnparsedPacket(message.toByteArray())))
         receivedDataFuture.get() shouldBe message
 
         serverRunning = false


### PR DESCRIPTION
'receiver' classes

i bumped into this a bit when implementing the DTLS server code and noticed the methods here are generic and don't need to be DTLS specific (which was making some refactoring related to the DTLS server stuff more complicated)