### PR TITLE
Adds generic properties to PacketInfo.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -17,6 +17,7 @@ package org.jitsi.nlj
 
 import org.jitsi.rtp.Packet
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 
 class EventTimeline(
     private val timeline: MutableList<Pair<String, Long>> = mutableListOf()
@@ -99,6 +100,8 @@ class PacketInfo @JvmOverloads constructor(
     fun resetPayloadVerification() {
         payloadVerification = if (ENABLE_PAYLOAD_VERIFICATION) packet.payloadVerification else null
     }
+
+    val properties: MutableMap<String, String> = ConcurrentHashMap()
 
     /**
      * Get the contained packet cast to [ExpectedPacketType]


### PR DESCRIPTION
Don't merge. Just throwing this out there to see if Brian will have a heart attack :)

For Octo we have one Node pipeline that handles packets coming from multiple endpoints. I want to store a `sourceEndpointId` as a property of `PacketInfo`, because I don't really like the other solution (look it up again based on SSRC). If we do decide to use this I'll implement it properly