### PR TITLE
fix a bug when updating the last extended high seq num

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -103,7 +103,8 @@ public class BandwidthEstimatorImpl
         {
             Long ssrc = reportBlock.getSsrc();
             Long extSeqNum = reportBlock.getExtendedHighestSeqNum();
-            Long lastEHSN = ssrc_to_last_received_extended_high_seq_num_.computeIfAbsent(ssrc, key -> extSeqNum);
+            Long lastEHSN = ssrc_to_last_received_extended_high_seq_num_.getOrDefault(ssrc, extSeqNum);
+            ssrc_to_last_received_extended_high_seq_num_.put(ssrc, lastEHSN);
 
             if (lastEHSN >= extSeqNum)
             {


### PR DESCRIPTION
Someone pointed this bug out a while ago [here](https://github.com/jitsi/jitsi-media-transform/issues/5).  I believe this now does what it originally did, but please do double check me.