### PR TITLE
fixes regression in encoding bitrate calculation

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/MediaStreamTrackDesc.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/MediaStreamTrackDesc.java
@@ -39,10 +39,9 @@ public class MediaStreamTrackDesc
     private final RTPEncodingDesc[] rtpEncodings;
 
     /**
-     * Allow the lookup of an encoding by the SSRC of a received packet.  Note
-     * that multiple SSRCs in this map may point to the same encoding.
+     * Allow the lookup of an encoding by the encoding id of a received packet.
      */
-    private final Map<Long, RTPEncodingDesc> encodingsBySsrc = new HashMap<>();
+    private final Map<Long, RTPEncodingDesc> encodingsById = new HashMap<>();
 
     /**
      * A string which identifies the owner of this track (e.g. the endpoint
@@ -80,14 +79,7 @@ public class MediaStreamTrackDesc
     {
         for (RTPEncodingDesc encoding : this.rtpEncodings)
         {
-            long encodingId = encoding.getPrimarySSRC();
-            long tid = encoding.getTemporalLayerId();
-            if (tid > -1)
-            {
-                encodingId |= tid << 32;
-            }
-
-            encodingsBySsrc.put(encodingId, encoding);
+            encodingsById.put(encoding.getEncodingId(), encoding);
         }
     }
 
@@ -148,14 +140,8 @@ public class MediaStreamTrackDesc
             return null;
         }
 
-        long encodingId = videoRtpPacket.getSsrc();
-        if (videoRtpPacket instanceof Vp8Packet)
-        {
-            long tid = ((Vp8Packet) videoRtpPacket).getTemporalLayerIndex();
-            encodingId |= tid << 32;
-        }
-
-        RTPEncodingDesc desc = encodingsBySsrc.get(encodingId);
+        long encodingId = RTPEncodingDesc.getEncodingId(videoRtpPacket);
+        RTPEncodingDesc desc = encodingsById.get(encodingId);
         if (desc != null)
         {
             return desc;

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
@@ -255,8 +255,8 @@ public class RTPEncodingDesc
             // check that here (note, though, that the spatial layer index in a packet is currently set as of
             // the time of this writing and is from the perspective of a logical spatial index, i.e. the lowest sim
             // stream (180p) has spatial index 0, 360p has 1, 720p has 2.
-            return tid == vp8Packet.getTemporalLayerIndex();
-
+            int vp8PacketTid = vp8Packet.getTemporalLayerIndex();
+            return (tid == vp8PacketTid) || (vp8PacketTid == -1 && tid == 0);
         }
         else
         {

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
@@ -242,11 +242,11 @@ public class RTPEncodingDesc
         {
             return false;
         }
-        if (tid == -1 && sid == -1)
+        else if (tid == -1 && sid == -1)
         {
             return true;
         }
-        if (packet instanceof Vp8Packet)
+        else if (packet instanceof Vp8Packet)
         {
             Vp8Packet vp8Packet = (Vp8Packet)packet;
             // NOTE(brian): the spatial layer index of an encoding is only currently used for in-band spatial
@@ -382,5 +382,10 @@ public class RTPEncodingDesc
     public boolean isReceived()
     {
         return numOfReceivers.get() > 0;
+    }
+
+    public int getTemporalLayerId()
+    {
+        return tid;
     }
 }

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
@@ -208,16 +208,6 @@ public class RTPEncodingDesc
     }
 
     /**
-     * Gets the last stable bitrate (in bps) for this instance.
-     *
-     * @return The last stable bitrate (in bps) for this instance.
-     */
-    public long getLastStableBitrateBps(long nowMs)
-    {
-        return rateStatistics.getRate(nowMs);
-    }
-
-    /**
      * Gets the primary SSRC for this layering/encoding.
      *
      * @return the primary SSRC for this layering/encoding.
@@ -366,7 +356,7 @@ public class RTPEncodingDesc
      * @param packetSizeBytes
      * @param nowMs
      */
-    public void update(int packetSizeBytes, long nowMs)
+    public void updateBitrate(int packetSizeBytes, long nowMs)
     {
         // Update rate stats (this should run after padding termination).
         rateStatistics.update(packetSizeBytes , nowMs);
@@ -380,7 +370,7 @@ public class RTPEncodingDesc
      * @return the cumulative bitrate (in bps) of this {@link RTPEncodingDesc
      * and its dependencies.
      */
-    private long getBitrateBps(long nowMs)
+    public long getBitrateBps(long nowMs)
     {
         RTPEncodingDesc[] encodings = track.getRTPEncodings();
         if (ArrayUtils.isNullOrEmpty(encodings))

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/RTPEncodingDesc.java
@@ -18,7 +18,6 @@ package org.jitsi_modified.impl.neomedia.rtp;
 import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.utils.*;
-import org.jitsi.utils.logging.*;
 import org.jitsi.utils.stats.*;
 
 import java.util.*;
@@ -38,13 +37,6 @@ public class RTPEncodingDesc
     public static final int SUSPENDED_INDEX = -1;
 
     /**
-     * The {@link Logger} used by the {@link RTPEncodingDesc class to print
-     * debug information.
-     */
-    private static final Logger logger
-        = Logger.getLogger(RTPEncodingDesc.class);
-
-    /**
      * A value used to designate the absence of height information.
      */
     private final static int NO_HEIGHT = -1;
@@ -60,21 +52,6 @@ public class RTPEncodingDesc
      * TODO maybe make this configurable.
      */
     private static final int AVERAGE_BITRATE_WINDOW_MS = 5000;
-
-    /**
-     * The number of incoming frames to keep track of.
-     */
-    private static final int FRAMES_HISTORY_SZ = 60;
-
-     /**
-      * The maximum time interval (in millis) an encoding can be considered
-      * active without new frames. This value corresponds to 4fps + 50 millis
-      * to compensate for network noise. If the network is clogged and we don't
-      * get a new frame within 300 millis, and if the encoding is being
-      * received, then we will ask for a new key frame (this is done in the
-      * JVB in SimulcastController).
-      */
-    private static final int SUSPENSION_THRESHOLD_MS = 300;
 
     /**
      * The primary SSRC for this layering/encoding.
@@ -250,16 +227,6 @@ public class RTPEncodingDesc
     }
 
     /**
-     * Gets the {@link MediaStreamTrackDesc} that this instance belongs to.
-     *
-     * @return the {@link MediaStreamTrackDesc} that this instance belongs to.
-     */
-    public MediaStreamTrackDesc getMediaStreamTrack()
-    {
-        return track;
-    }
-
-    /**
      * Gets the subjective quality index of this instance.
      *
      * @return the subjective quality index of this instance.
@@ -267,45 +234,6 @@ public class RTPEncodingDesc
     public int getIndex()
     {
         return idx;
-    }
-
-    /**
-     * Returns a boolean that indicates whether or not this
-     * {@link RTPEncodingDesc depends on the subjective quality index that is
-     * passed as an argument.
-     *
-     * @param idx the index of this instance in the track encodings array.
-     * @return true if this {@link RTPEncodingDesc depends on the subjective
-     * quality index that is passed as an argument, false otherwise.
-     */
-    public boolean requires(int idx)
-    {
-        if (idx < 0)
-        {
-            return false;
-        }
-
-        if (idx == this.idx)
-        {
-            return true;
-        }
-
-
-        boolean requires = false;
-
-        if (!ArrayUtils.isNullOrEmpty(dependencyEncodings))
-        {
-            for (RTPEncodingDesc enc : dependencyEncodings)
-            {
-                if (enc.requires(idx))
-                {
-                    requires = true;
-                    break;
-                }
-            }
-        }
-
-        return requires;
     }
 
     boolean matches(VideoRtpPacket packet)

--- a/src/main/kotlin/org/jitsi/nlj/MediaStreamTracks.kt
+++ b/src/main/kotlin/org/jitsi/nlj/MediaStreamTracks.kt
@@ -78,7 +78,7 @@ fun RTPEncodingDesc.getNodeStats() = NodeStatsBlock(primarySSRC.toString()).appl
     addNumber("frameRate", frameRate)
     addNumber("height", height)
     addNumber("index", index)
-    addNumber("last_stable_bitrate_bps", getLastStableBitrateBps(System.currentTimeMillis()))
+    addNumber("bitrate_bps", getBitrateBps(System.currentTimeMillis()))
     addBoolean("is_received", isReceived)
     addNumber("rtx_ssrc", getSecondarySsrc(SsrcAssociationType.RTX))
     addNumber("fec_ssrc", getSecondarySsrc(SsrcAssociationType.FEC))

--- a/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
@@ -22,10 +22,6 @@ open class VideoRtpPacket(
     offset: Int,
     length: Int
 ) : RtpPacket(buffer, offset, length) {
-    /**
-     * The estimated bitrate of the encoding to which this packet belongs
-     */
-    var bitrateSnapshot: Long? = null
     var isKeyframe = false
     var qualityIndex = -1
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
@@ -38,8 +38,7 @@ class VideoBitrateCalculator : ObserverNode("Video bitrate calculator") {
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket
         findRtpEncodingDesc(videoRtpPacket)?.let {
             val now = System.currentTimeMillis()
-            it.update(videoRtpPacket.length, now)
-            videoRtpPacket.bitrateSnapshot = it.getLastStableBitrateBps(now)
+            it.updateBitrate(videoRtpPacket.length, now)
         }
     }
 


### PR DESCRIPTION
provides https://github.com/jitsi/jitsi-videobridge/pull/836

this pr fixes the bitrate computation for temporal layers in the bridge (currently the bitrate for temporal layers is always 0).

a notable change/proposal in this pr is the removal of the `bitrateSnapshot` property from the video packet.

currently it's not used anywhere; I believe this was intended to be used in bandwidth probing and in the bandwidth distribution algorithm? anywhere else?

since a video packet can be required by multiple encodings (i.e. a 720p15fps packet is required by both 720p30fps and 720p15fps due to temporal scalability), which encoding does the bitrate refer to and how is that useful in bandwidth probing and in the bandwidth distribution algorithm (or anywhere else that this property was intended to be used)?