### PR TITLE
fix SrtpTransformerNode concurrent modification

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -57,7 +57,7 @@ class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode(name) {
         if (firstPacketReceivedTimestamp == -1L) {
             firstPacketReceivedTimestamp = System.currentTimeMillis()
         }
-        transformer?.let {
+        transformer?.let { transformer ->
             if (firstPacketForwardedTimestamp == -1L) {
                 firstPacketForwardedTimestamp = System.currentTimeMillis()
             }
@@ -67,7 +67,7 @@ class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode(name) {
                 outPackets = transformList(cachedPackets)
                 cachedPackets.clear()
             } else {
-                outPackets = if (transformer!!.transform(packetInfo))
+                outPackets = if (transformer.transform(packetInfo))
                     listOf(packetInfo) else emptyList()
             }
             return outPackets

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/RtpReceiverHarness.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/RtpReceiverHarness.kt
@@ -18,6 +18,7 @@ package org.jitsi.nlj.module_tests
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpReceiver
 import org.jitsi.nlj.util.safeShutdown
+import org.jitsi.service.libjitsi.LibJitsi
 import org.jitsi.test_utils.Pcaps
 import java.time.Duration
 import java.util.concurrent.Executors
@@ -35,6 +36,9 @@ import kotlin.system.measureTimeMillis
  */
 
 fun main(args: Array<String>) {
+    // We need to start libjitsi so that the openssl lib gets loaded.
+    LibJitsi.start()
+
     val pcap = Pcaps.Incoming.ONE_PARTICIPANT_RTP_RTCP_SIM_RTX
 
     val producer = PcapPacketProducer(pcap.filePath)


### PR DESCRIPTION
I initially looked at using `CopyOnWriteArrayList` for `cachedPackets` and that did address the concurrent modification problem, but, in (likely rare) cases it could lead to 'lost packets'.  I decided to try simple synchronization as a data point and found it didn't appear to perform noticeably worse than the original implementation, so that's what I've got here.  Some measurements:

|| As-is (ArrayList) | CopyOnWriteArrayList | Synchronized |
|---|---|---|---|
||21783|20826|17422|
||19827|19931|20855|
||21920|21947|22289|
||20279|20608|17576|
||21633|21787|18861|
||19370|19694|18349|
|avg|20802|20798|19225|

(Obviously I doubt this is somehow magically _faster_ than the original, I'm sure there's noise, but there doesn't seem to be a noticeable impact).

I think this fix is at least good enough to get us through merging and we can revisit.  In the long run I'm still interested in investigating the idea of a 'no-lock' pipeline, if we can pull that off.