### PR TITLE
track Packet delay stats

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -46,18 +46,23 @@ class EventTimeline(
 
     /**
      * Return the total time between this packet's first event and last event
+     * or -1 if there is no reference time
      */
     fun totalDelay(): Duration {
         return referenceTime?.let {
             return Duration.ofMillis(timeline.last().second)
-        } ?: Duration.ofMillis(0)
+        } ?: Duration.ofMillis(-1)
     }
 
     override fun toString(): String {
         return with(StringBuffer()) {
-            appendln("Reference time: ${referenceTime}ms")
-            timeline.forEach {
-                appendln(it.toString())
+            referenceTime?.let {
+                appendln("Reference time: ${referenceTime}ms")
+                timeline.forEach {
+                    appendln(it.toString())
+                }
+            } ?: run {
+                appendln("[No timeline]")
             }
             toString()
         }

--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -143,7 +143,7 @@ open class PacketInfo @JvmOverloads constructor(
 
     companion object {
         // TODO: we could make this a public var to allow changing this at runtime
-        const val ENABLE_TIMELINE = true
+        private const val ENABLE_TIMELINE = false
 
         /**
          * If this is enabled all [Node]s will verify that the payload didn't unexpectedly change. This is expensive.

--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -143,7 +143,7 @@ open class PacketInfo @JvmOverloads constructor(
 
     companion object {
         // TODO: we could make this a public var to allow changing this at runtime
-        private const val ENABLE_TIMELINE = false
+        const val ENABLE_TIMELINE = true
 
         /**
          * If this is enabled all [Node]s will verify that the payload didn't unexpectedly change. This is expensive.

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -110,7 +110,10 @@ class RtpSenderImpl(
                 totalDelayMs += delayMs
                 if (delayMs > maxDelayMs) {
                     maxDelayMs = delayMs
-                    logger.cerror { "New max packet delay $maxDelayMs:\n${packetInfo.timeline}" }
+                    logger.cerror {
+                        "New max packet delay $maxDelayMs" +
+                            if (PacketInfo.ENABLE_TIMELINE) ":\n${packetInfo.timeline}" else ""
+                    }
                 }
                 totalPackets++
             }

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -95,7 +95,6 @@ class RtpSenderImpl(
 
     private val outputPipelineTerminationNode = object : ConsumerNode("Output pipeline termination node") {
         override fun consume(packetInfo: PacketInfo) {
-            packetDelayStats.addPacket(packetInfo)
             // While there's no handler set we're effectively dropping packets, so their buffers
             // should be returned.
             outgoingPacketHandler?.processPacket(packetInfo) ?: packetDiscarded(packetInfo)
@@ -243,7 +242,6 @@ class RtpSenderImpl(
     companion object {
         private val classLogger: Logger = Logger.getLogger(this::class.java)
         val queueErrorCounter = CountingErrorHandler()
-        val packetDelayStats = PacketDelayStats()
 
         private const val PACKET_QUEUE_ENTRY_EVENT = "Entered RTP sender incoming queue"
         private const val PACKET_QUEUE_EXIT_EVENT = "Exited RTP sender incoming queue"

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -20,7 +20,6 @@ import org.jitsi.nlj.rtcp.NackHandler
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtcp.RtcpSrUpdater
 import org.jitsi.nlj.srtp.SrtpTransformers
-import org.jitsi.nlj.stats.PacketDelayStats
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.NodeEventVisitor
 import org.jitsi.nlj.transform.NodeStatsVisitor

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -95,7 +95,7 @@ class RtpSenderImpl(
 
     private val outputPipelineTerminationNode = object : ConsumerNode("Output pipeline termination node") {
         override fun consume(packetInfo: PacketInfo) {
-            delayStats.addPacket(packetInfo)
+            packetDelayStats.addPacket(packetInfo)
             // While there's no handler set we're effectively dropping packets, so their buffers
             // should be returned.
             outgoingPacketHandler?.processPacket(packetInfo) ?: packetDiscarded(packetInfo)
@@ -243,7 +243,7 @@ class RtpSenderImpl(
     companion object {
         private val classLogger: Logger = Logger.getLogger(this::class.java)
         val queueErrorCounter = CountingErrorHandler()
-        val delayStats = PacketDelayStats()
+        val packetDelayStats = PacketDelayStats()
 
         private const val PACKET_QUEUE_ENTRY_EVENT = "Entered RTP sender incoming queue"
         private const val PACKET_QUEUE_EXIT_EVENT = "Exited RTP sender incoming queue"

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -20,7 +20,7 @@ import org.jitsi.nlj.rtcp.NackHandler
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtcp.RtcpSrUpdater
 import org.jitsi.nlj.srtp.SrtpTransformers
-import org.jitsi.nlj.stats.DelayStats
+import org.jitsi.nlj.stats.PacketDelayStats
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.NodeEventVisitor
 import org.jitsi.nlj.transform.NodeStatsVisitor
@@ -39,7 +39,6 @@ import org.jitsi.nlj.transform.node.outgoing.TccSeqNumTagger
 import org.jitsi.nlj.transform.pipeline
 import org.jitsi.nlj.util.PacketInfoQueue
 import org.jitsi.nlj.util.cdebug
-import org.jitsi.nlj.util.cerror
 import org.jitsi.nlj.util.getLogger
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.utils.MediaType
@@ -244,10 +243,9 @@ class RtpSenderImpl(
     companion object {
         private val classLogger: Logger = Logger.getLogger(this::class.java)
         val queueErrorCounter = CountingErrorHandler()
-        val delayStats = DelayStats()
+        val delayStats = PacketDelayStats()
 
         private const val PACKET_QUEUE_ENTRY_EVENT = "Entered RTP sender incoming queue"
         private const val PACKET_QUEUE_EXIT_EVENT = "Exited RTP sender incoming queue"
     }
-
 }

--- a/src/main/kotlin/org/jitsi/nlj/stats/DelayStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/DelayStats.kt
@@ -20,25 +20,31 @@ import org.jitsi.nlj.PacketInfo
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.LongAdder
 
-class PacketDelayStats {
+open class DelayStats {
     private val totalDelayMs = LongAdder()
-    private val totalPackets = LongAdder()
+    private val totalCount = LongAdder()
     val averageDelay: Double
-        get() = totalDelayMs.sum() / totalPackets.sum().toDouble()
+        get() = totalDelayMs.sum() / totalCount.sum().toDouble()
     val maxDelayMs = AtomicLong(0)
 
+    fun addDelay(delayMs: Long) {
+        if (delayMs >= 0) {
+            totalDelayMs.add(delayMs)
+            if (delayMs > maxDelayMs.get()) {
+                maxDelayMs.set(delayMs)
+            }
+            totalCount.increment()
+        }
+    }
+}
+
+class PacketDelayStats : DelayStats() {
     fun addPacket(packetInfo: PacketInfo) {
         val delayMs = if (packetInfo.receivedTime > 0) {
             System.currentTimeMillis() - packetInfo.receivedTime
         } else {
             -1
         }
-        if (delayMs >= 0) {
-            totalDelayMs.add(delayMs)
-            if (delayMs > maxDelayMs.get()) {
-                maxDelayMs.set(delayMs)
-            }
-            totalPackets.increment()
-        }
+        addDelay(delayMs)
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/stats/JsonStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/JsonStats.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("JsonStats")
+
+package org.jitsi.nlj.stats
+
+import org.jitsi.nlj.util.OrderedJsonObject
+
+
+fun DelayStats.toJson(): OrderedJsonObject {
+    return OrderedJsonObject().apply {
+        put("average_delay_ms", averageDelay)
+        put("max_delay_ms", maxDelayMs)
+    }
+}

--- a/src/main/kotlin/org/jitsi/nlj/stats/JsonStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/JsonStats.kt
@@ -20,7 +20,6 @@ package org.jitsi.nlj.stats
 
 import org.jitsi.nlj.util.OrderedJsonObject
 
-
 fun DelayStats.toJson(): OrderedJsonObject {
     return OrderedJsonObject().apply {
         put("average_delay_ms", averageDelay)

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketDelayStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketDelayStats.kt
@@ -18,12 +18,13 @@ package org.jitsi.nlj.stats
 
 import org.jitsi.nlj.PacketInfo
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.LongAdder
 
 class DelayStats {
-    private val totalDelayMs = AtomicLong(0)
-    private val totalPackets = AtomicLong(0)
+    private val totalDelayMs = LongAdder()
+    private val totalPackets = LongAdder()
     val averageDelay: Double
-        get() = totalDelayMs.get() / totalPackets.get().toDouble()
+        get() = totalDelayMs.sum() / totalPackets.sum().toDouble()
     val maxDelayMs = AtomicLong(0)
 
     fun addPacket(packetInfo: PacketInfo) {
@@ -33,11 +34,11 @@ class DelayStats {
             -1
         }
         if (delayMs >= 0) {
-            totalDelayMs.addAndGet(delayMs)
+            totalDelayMs.add(delayMs)
             if (delayMs > maxDelayMs.get()) {
                 maxDelayMs.set(delayMs)
             }
-            totalPackets.incrementAndGet()
+            totalPackets.increment()
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketDelayStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketDelayStats.kt
@@ -20,7 +20,7 @@ import org.jitsi.nlj.PacketInfo
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.LongAdder
 
-class DelayStats {
+class PacketDelayStats {
     private val totalDelayMs = LongAdder()
     private val totalPackets = LongAdder()
     val averageDelay: Double

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketDelayStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketDelayStats.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.stats
+
+import org.jitsi.nlj.PacketInfo
+import java.util.concurrent.atomic.AtomicLong
+
+class DelayStats {
+    private val totalDelayMs = AtomicLong(0)
+    private val totalPackets = AtomicLong(0)
+    val averageDelay: Double
+        get() = totalDelayMs.get() / totalPackets.get().toDouble()
+    val maxDelayMs = AtomicLong(0)
+
+    fun addPacket(packetInfo: PacketInfo) {
+        val delayMs = if (packetInfo.receivedTime > 0) {
+            System.currentTimeMillis() - packetInfo.receivedTime
+        } else {
+            -1
+        }
+        if (delayMs >= 0) {
+            totalDelayMs.addAndGet(delayMs)
+            if (delayMs > maxDelayMs.get()) {
+                maxDelayMs.set(delayMs)
+            }
+            totalPackets.incrementAndGet()
+        }
+    }
+}


### PR DESCRIPTION
this change tracks an average and max delay for packets at the end of the RTP sender pipeline.  this will track stats for any packet whose `receivedTime` is `>= 0`.  i'm not sure we're 100% compliant with this idea, but i think the convention we should use is only to set `PacketInfo.receivedTime` for packets received from the network (so it should remain unused for things like RTCP we generate, for example).  We should probably also clear this value for packets we retransmit, as that could throw off the stats.  (i also looked at filtering for RTP only by checking the packet type, but things are encrypted so they're all `UnparsedPacket` at this point, so went with the `receivedTime` scheme)

whenever a new maximum delay is encountered, we print the timeline which will give information as to where the packet 'sat' (if the timeline is enabled).  i'll take a look at adding the same stat at the end of the receive pipeline as well.