### PR TITLE
Fixes transport-wide sequence number boundary handling

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
@@ -161,6 +161,7 @@ public class TransportCCEngine
 
             if (packetDetail == null)
             {
+                logger.warn("Couldn't find packet detail for " + tccSeqNum + ".");
                 continue;
             }
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
@@ -186,7 +186,7 @@ public class TransportCCEngine
         {
             long now = System.currentTimeMillis();
             sentPacketDetails.put(
-                    tccSeqNum,
+                    tccSeqNum & 0xFFFF,
                     new PacketDetail(length, now));
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -52,7 +52,7 @@ import java.util.concurrent.ScheduledExecutorService
 
 class RtpSenderImpl(
     val id: String,
-    transportCcEngine: TransportCCEngine? = null,
+    val transportCcEngine: TransportCCEngine? = null,
     private val rtcpEventNotifier: RtcpEventNotifier,
     /**
      * The executor this class will use for its primary work (i.e. critical path
@@ -165,6 +165,7 @@ class RtpSenderImpl(
     override fun onRttUpdate(newRtt: Double) {
         nackHandler.onRttUpdate(newRtt)
         keyframeRequester.onRttUpdate(newRtt)
+        transportCcEngine?.onRttUpdate(newRtt.toLong(), -1)
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -140,7 +140,7 @@ class KeyframeRequester : TransformerNode("Keyframe Requester") {
                 false
             } else {
                 keyframeRequests[mediaSsrc] = nowMs
-                logger.cdebug { "Keyframe requester requesting keyframe with FIR for $mediaSsrc" }
+                logger.cdebug { "Keyframe requester requesting keyframe for $mediaSsrc" }
                 true
             }
         }


### PR DESCRIPTION
not sure if this fixes everything, and we probably have some utility method that can take care of the bitwise operation