### PR TITLE
Centralize stream information events

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/Event.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Event.kt
@@ -16,7 +16,6 @@
 package org.jitsi.nlj
 
 import org.jitsi.nlj.format.PayloadType
-import org.jitsi.nlj.rtp.RtpExtension
 import org.jitsi.nlj.rtp.SsrcAssociationType
 import org.jitsi.utils.MediaType
 import org.jitsi_modified.impl.neomedia.rtp.MediaStreamTrackDesc
@@ -30,11 +29,6 @@ class RtpPayloadTypeAddedEvent(val payloadType: PayloadType) : Event {
     }
 }
 class RtpPayloadTypeClearEvent : Event
-
-@Deprecated("subscribe to a StreamInformationStore instead")
-class RtpExtensionAddedEvent(val rtpExtension: RtpExtension) : Event
-@Deprecated("subscribe to a StreamInformationStore instead")
-class RtpExtensionClearEvent : Event
 
 class ReceiveSsrcAddedEvent(val ssrc: Long) : Event
 class ReceiveSsrcRemovedEvent(val ssrc: Long) : Event

--- a/src/main/kotlin/org/jitsi/nlj/Event.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Event.kt
@@ -31,7 +31,9 @@ class RtpPayloadTypeAddedEvent(val payloadType: PayloadType) : Event {
 }
 class RtpPayloadTypeClearEvent : Event
 
+@Deprecated("subscribe to a StreamInformationStore instead")
 class RtpExtensionAddedEvent(val rtpExtension: RtpExtension) : Event
+@Deprecated("subscribe to a StreamInformationStore instead")
 class RtpExtensionClearEvent : Event
 
 class ReceiveSsrcAddedEvent(val ssrc: Long) : Event

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -45,6 +45,7 @@ import org.jitsi.nlj.transform.packetPath
 import org.jitsi.nlj.transform.pipeline
 import org.jitsi.nlj.util.PacketInfoQueue
 import org.jitsi.nlj.util.PacketPredicate
+import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.getLogger
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -77,6 +78,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
      * Returns the current sending bitrate in bps.
      */
     getSendBitrate: () -> Long,
+    streamInformationStore: StreamInformationStore,
     logLevelDelegate: Logger? = null
 ) : RtpReceiver() {
     private val logger = getLogger(classLogger, logLevelDelegate)
@@ -87,7 +89,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
     private val srtpDecryptWrapper = SrtpTransformerNode("SRTP Decrypt node")
     private val srtcpDecryptWrapper = SrtpTransformerNode("SRTCP Decrypt node")
     private val tccGenerator = TccGeneratorNode(rtcpSender, backgroundExecutor, getSendBitrate)
-    private val audioLevelReader = AudioLevelReader()
+    private val audioLevelReader = AudioLevelReader(streamInformationStore)
     private val silenceDiscarder = SilenceDiscarder(true)
     private val statsTracker = IncomingStatisticsTracker()
     private val packetStreamStats = PacketStreamStatsNode()

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -37,6 +37,7 @@ import org.jitsi.nlj.transform.node.outgoing.SentRtcpStats
 import org.jitsi.nlj.transform.node.outgoing.TccSeqNumTagger
 import org.jitsi.nlj.transform.pipeline
 import org.jitsi.nlj.util.PacketInfoQueue
+import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.getLogger
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -63,6 +64,7 @@ class RtpSenderImpl(
      * background tasks, or tasks that need to execute at some fixed delay/rate
      */
     val backgroundExecutor: ScheduledExecutorService,
+    private val streamInformationStore: StreamInformationStore,
     logLevelDelegate: Logger? = null,
     diagnosticContext: DiagnosticContext = DiagnosticContext()
 ) : RtpSender() {
@@ -84,7 +86,7 @@ class RtpSenderImpl(
     private val srtpEncryptWrapper = SrtpTransformerNode("SRTP encrypt")
     private val srtcpEncryptWrapper = SrtpTransformerNode("SRTCP encrypt")
     private val outgoingPacketCache = PacketCacher()
-    private val absSendTime = AbsSendTime()
+    private val absSendTime = AbsSendTime(streamInformationStore)
     private val statsTracker = OutgoingStatisticsTracker()
     private val packetStreamStats = PacketStreamStatsNode()
     private val rtcpSrUpdater = RtcpSrUpdater(statsTracker)

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -112,7 +112,7 @@ class RtpSenderImpl(
             node(outgoingPacketCache)
             node(absSendTime)
             node(statsTracker)
-            node(TccSeqNumTagger(transportCcEngine))
+            node(TccSeqNumTagger(transportCcEngine, streamInformationStore))
             node(srtpEncryptWrapper)
             node(packetStreamStats.createNewNode())
             node(outputPipelineTerminationNode)

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -219,9 +219,6 @@ class Transceiver(
     fun addRtpExtension(rtpExtension: RtpExtension) {
         logger.cdebug { "Adding RTP extension: $rtpExtension" }
         streamInformationStore.addRtpExtensionMapping(rtpExtension)
-        val rtpExtensionAddedEvent = RtpExtensionAddedEvent(rtpExtension)
-        rtpReceiver.handleEvent(rtpExtensionAddedEvent)
-        rtpSender.handleEvent(rtpExtensionAddedEvent)
     }
 
     fun clearRtpExtensions() {

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -94,6 +94,7 @@ class Transceiver(
             rtcpEventNotifier,
             senderExecutor,
             backgroundExecutor,
+            streamInformationStore,
             logLevelDelegate,
             diagnosticContext
     )

--- a/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
+++ b/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
@@ -22,6 +22,9 @@ import java.util.concurrent.CopyOnWriteArraySet
 typealias PayloadTypeParams = Map<String, String>
 
 typealias RtcpFeedbackSet = Set<String>
+
+fun RtcpFeedbackSet.supportsPli(): Boolean = this.contains("nack pli")
+fun RtcpFeedbackSet.supportsFir(): Boolean = this.contains("ccm fir")
 /**
  * Represents an RTP payload type.
  *

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -22,6 +22,8 @@ import org.jitsi.nlj.RtpPayloadTypeAddedEvent
 import org.jitsi.nlj.RtpPayloadTypeClearEvent
 import org.jitsi.nlj.SetLocalSsrcEvent
 import org.jitsi.nlj.format.VideoPayloadType
+import org.jitsi.nlj.format.supportsFir
+import org.jitsi.nlj.format.supportsPli
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.TransformerNode
 import org.jitsi.nlj.util.cdebug
@@ -32,7 +34,6 @@ import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbFirPacketBuilder
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacketBuilder
 import org.jitsi.utils.MediaType
-import java.lang.IllegalStateException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.min
 
@@ -188,8 +189,8 @@ class KeyframeRequester : TransformerNode("Keyframe Requester") {
                         // our code which requests FIR and PLI is not payload-type aware. So
                         // until this changes we will just check if any of the PTs supports
                         // FIR and PLI. This means that we effectively always assume support for FIR.
-                        hasPliSupport = hasPliSupport || event.payloadType.rtcpFeedbackSet.contains("nack pli")
-                        hasFirSupport = hasFirSupport || event.payloadType.rtcpFeedbackSet.contains("ccm fir")
+                        hasPliSupport = hasPliSupport || event.payloadType.rtcpFeedbackSet.supportsPli()
+                        hasFirSupport = hasFirSupport || event.payloadType.rtcpFeedbackSet.supportsFir()
                     }
                 }
             }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -16,25 +16,23 @@
 package org.jitsi.nlj.transform.node.incoming
 
 import org.jitsi.nlj.AudioLevelListener
-import org.jitsi.nlj.Event
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.AudioRtpPacket
 import org.jitsi.nlj.rtp.RtpExtensionType.SSRC_AUDIO_LEVEL
 import org.jitsi.nlj.transform.node.ObserverNode
-import org.jitsi.nlj.util.StreamInformation
+import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.rtp.extensions.unsigned.toPositiveLong
 import org.jitsi.rtp.rtp.header_extensions.AudioLevelHeaderExtension
 
 /**
  * https://tools.ietf.org/html/rfc6464#section-3
  */
-class AudioLevelReader : ObserverNode("Audio level reader") {
+class AudioLevelReader(streamInformationStore: StreamInformationStore) : ObserverNode("Audio level reader") {
     private var audioLevelExtId: Int? = null
     var audioLevelListener: AudioLevelListener? = null
-    private val streamInformation = StreamInformation()
 
     init {
-        streamInformation.onExtensionMapping(SSRC_AUDIO_LEVEL) {
+        streamInformationStore.onRtpExtensionMapping(SSRC_AUDIO_LEVEL) {
             audioLevelExtId = it
         }
     }
@@ -57,6 +55,4 @@ class AudioLevelReader : ObserverNode("Audio level reader") {
             }
         }
     }
-
-    override fun handleEvent(event: Event) = streamInformation.handleEvent(event)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -18,15 +18,12 @@ package org.jitsi.nlj.transform.node.incoming
 import org.jitsi.nlj.AudioLevelListener
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.PacketInfo
-import org.jitsi.nlj.RtpExtensionAddedEvent
-import org.jitsi.nlj.RtpExtensionClearEvent
 import org.jitsi.nlj.rtp.AudioRtpPacket
 import org.jitsi.nlj.rtp.RtpExtensionType.SSRC_AUDIO_LEVEL
 import org.jitsi.nlj.transform.node.ObserverNode
-import org.jitsi.nlj.util.cdebug
+import org.jitsi.nlj.util.StreamInformation
 import org.jitsi.rtp.extensions.unsigned.toPositiveLong
 import org.jitsi.rtp.rtp.header_extensions.AudioLevelHeaderExtension
-import unsigned.toUInt
 
 /**
  * https://tools.ietf.org/html/rfc6464#section-3
@@ -34,6 +31,14 @@ import unsigned.toUInt
 class AudioLevelReader : ObserverNode("Audio level reader") {
     private var audioLevelExtId: Int? = null
     var audioLevelListener: AudioLevelListener? = null
+    private val streamInformation = StreamInformation()
+
+    init {
+        streamInformation.onExtensionMapping(SSRC_AUDIO_LEVEL) {
+            audioLevelExtId = it
+        }
+    }
+
     companion object {
         const val MUTED_LEVEL = 127
     }
@@ -53,15 +58,5 @@ class AudioLevelReader : ObserverNode("Audio level reader") {
         }
     }
 
-    override fun handleEvent(event: Event) {
-        when (event) {
-            is RtpExtensionAddedEvent -> {
-                if (event.rtpExtension.type == SSRC_AUDIO_LEVEL) {
-                    audioLevelExtId = event.rtpExtension.id.toUInt()
-                    logger.cdebug { "Setting extension ID to $audioLevelExtId" }
-                }
-            }
-            is RtpExtensionClearEvent -> audioLevelExtId = null
-        }
-    }
+    override fun handleEvent(event: Event) = streamInformation.handleEvent(event)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -19,11 +19,10 @@ import org.jitsi.nlj.Event
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.ReceiveSsrcAddedEvent
 import org.jitsi.nlj.ReceiveSsrcRemovedEvent
-import org.jitsi.nlj.RtpExtensionAddedEvent
-import org.jitsi.nlj.RtpExtensionClearEvent
 import org.jitsi.nlj.rtp.RtpExtensionType.TRANSPORT_CC
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ObserverNode
+import org.jitsi.nlj.util.StreamInformation
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.isOlderThan
 import org.jitsi.rtp.extensions.unsigned.toPositiveLong
@@ -34,7 +33,6 @@ import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.TccHeaderExtension
 import org.jitsi.rtp.util.RtpUtils
 import org.jitsi.utils.stats.RateStatistics
-import unsigned.toUInt
 import java.util.TreeMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -48,6 +46,7 @@ class TccGeneratorNode(
     private val scheduler: ScheduledExecutorService,
     private val getSendBitrate: () -> Long
 ) : ObserverNode("TCC generator") {
+    private val streamInformation = StreamInformation()
     private var tccExtensionId: Int? = null
     private var currTccSeqNum: Int = 0
     private var lastTccSentTime: Long = 0
@@ -70,6 +69,9 @@ class TccGeneratorNode(
     private var numTccSent: Int = 0
 
     init {
+        streamInformation.onExtensionMapping(TRANSPORT_CC) {
+            tccExtensionId = it
+        }
         reschedule()
     }
 
@@ -186,15 +188,9 @@ class TccGeneratorNode(
 
     override fun handleEvent(event: Event) {
         when (event) {
-            is RtpExtensionAddedEvent -> {
-                if (event.rtpExtension.type == TRANSPORT_CC) {
-                    tccExtensionId = event.rtpExtension.id.toUInt()
-                    logger.cdebug { "TCC generator setting extension ID to $tccExtensionId" }
-                }
-            }
-            is RtpExtensionClearEvent -> tccExtensionId = null
             is ReceiveSsrcAddedEvent -> mediaSsrcs.add(event.ssrc)
             is ReceiveSsrcRemovedEvent -> mediaSsrcs.remove(event.ssrc)
+            else -> streamInformation.handleEvent(event)
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -22,7 +22,7 @@ import org.jitsi.nlj.ReceiveSsrcRemovedEvent
 import org.jitsi.nlj.rtp.RtpExtensionType.TRANSPORT_CC
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ObserverNode
-import org.jitsi.nlj.util.StreamInformation
+import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.isOlderThan
 import org.jitsi.rtp.extensions.unsigned.toPositiveLong
@@ -46,7 +46,7 @@ class TccGeneratorNode(
     private val scheduler: ScheduledExecutorService,
     private val getSendBitrate: () -> Long
 ) : ObserverNode("TCC generator") {
-    private val streamInformation = StreamInformation()
+    private val streamInformation = StreamInformationStoreImpl()
     private var tccExtensionId: Int? = null
     private var currTccSeqNum: Int = 0
     private var lastTccSentTime: Long = 0
@@ -69,7 +69,7 @@ class TccGeneratorNode(
     private var numTccSent: Int = 0
 
     init {
-        streamInformation.onExtensionMapping(TRANSPORT_CC) {
+        streamInformation.onRtpExtensionMapping(TRANSPORT_CC) {
             tccExtensionId = it
         }
         reschedule()
@@ -190,7 +190,6 @@ class TccGeneratorNode(
         when (event) {
             is ReceiveSsrcAddedEvent -> mediaSsrcs.add(event.ssrc)
             is ReceiveSsrcRemovedEvent -> mediaSsrcs.remove(event.ssrc)
-            else -> streamInformation.handleEvent(event)
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -15,19 +15,21 @@
  */
 package org.jitsi.nlj.transform.node.outgoing
 
-import org.jitsi.nlj.Event
 import org.jitsi.nlj.PacketInfo
-import org.jitsi.nlj.RtpExtensionAddedEvent
-import org.jitsi.nlj.RtpExtensionClearEvent
 import org.jitsi.nlj.rtp.RtpExtensionType.ABS_SEND_TIME
 import org.jitsi.nlj.transform.node.TransformerNode
-import org.jitsi.nlj.util.cdebug
+import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.AbsSendTimeHeaderExtension
-import unsigned.toUInt
 
-class AbsSendTime : TransformerNode("Absolute send time") {
+class AbsSendTime(streamInformationStore: StreamInformationStore) : TransformerNode("Absolute send time") {
     private var extensionId: Int? = null
+
+    init {
+        streamInformationStore.onRtpExtensionMapping(ABS_SEND_TIME) {
+            extensionId = it
+        }
+    }
 
     override fun transform(packetInfo: PacketInfo): PacketInfo? {
         extensionId?.let { absSendTimeExtId ->
@@ -38,19 +40,5 @@ class AbsSendTime : TransformerNode("Absolute send time") {
         }
 
         return packetInfo
-    }
-
-    override fun handleEvent(event: Event) {
-        when (event) {
-            is RtpExtensionAddedEvent -> {
-                if (event.rtpExtension.type == ABS_SEND_TIME) {
-                    extensionId = event.rtpExtension.id.toUInt()
-                    logger.cdebug { "Setting extension ID to $extensionId" }
-                }
-            }
-            is RtpExtensionClearEvent -> {
-                extensionId = -1
-            }
-        }
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.util
+
+import org.jitsi.nlj.Event
+import org.jitsi.nlj.EventHandler
+import org.jitsi.nlj.ReceiveSsrcAddedEvent
+import org.jitsi.nlj.ReceiveSsrcRemovedEvent
+import org.jitsi.nlj.RtpExtensionAddedEvent
+import org.jitsi.nlj.RtpExtensionClearEvent
+import org.jitsi.nlj.rtp.RtpExtension
+import org.jitsi.nlj.rtp.RtpExtensionType
+
+/**
+ * A handler installed on a specific [RtpExtensionType] to be notified
+ * when that type is mapped to an id.  A null id value indicates the
+ * extension mapping has been removed
+ */
+typealias RtpExtensionHandler = (Int?) -> Unit
+
+/**
+ * [StreamInformation] manages various signalled information
+ * about streams on the scope of a [Transceiver].
+ *
+ */
+class StreamInformation : EventHandler {
+    val receiveSsrcs = mutableSetOf<Long>()
+    private val extensionsLock = Any()
+    private val extensionHandlers =
+        mutableMapOf<RtpExtensionType, MutableList<RtpExtensionHandler>>()
+    private val rtpExtensions = mutableListOf<RtpExtension>()
+
+    /**
+     * Video SSRCs received by this [Transceiver] which
+     * are for primary video, i.e. not FEC or RTX
+     * SSRCs
+     */
+    val receiveVideoSsrcs = mutableSetOf<Long>()
+
+    override fun handleEvent(event: Event) {
+        when (event) {
+            is ReceiveSsrcAddedEvent -> receiveSsrcs.add(event.ssrc)
+            is ReceiveSsrcRemovedEvent -> receiveSsrcs.remove(event.ssrc)
+            is RtpExtensionAddedEvent -> {
+                synchronized(extensionsLock) {
+                    rtpExtensions.add(event.rtpExtension)
+                    extensionHandlers.get(event.rtpExtension.type)?.forEach { it(event.rtpExtension.id.toInt()) }
+                }
+            }
+            is RtpExtensionClearEvent -> {
+                synchronized(extensionsLock) {
+                    rtpExtensions.clear()
+                    extensionHandlers.values.forEach { handlers -> handlers.forEach { it(null) } }
+                }
+            }
+        }
+    }
+
+    fun onExtensionMapping(rtpExtensionType: RtpExtensionType, handler: RtpExtensionHandler) {
+        synchronized(extensionsLock) {
+            extensionHandlers.getOrPut(rtpExtensionType, { mutableListOf() }).add(handler)
+            rtpExtensions.find { it.type == rtpExtensionType }?.let { handler(it.id.toInt()) }
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/ReceiverFactory.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/ReceiverFactory.kt
@@ -16,7 +16,6 @@
 
 package org.jitsi.nlj.module_tests
 
-import org.jitsi.nlj.RtpExtensionAddedEvent
 import org.jitsi.nlj.RtpPayloadTypeAddedEvent
 import org.jitsi.nlj.RtpReceiver
 import org.jitsi.nlj.RtpReceiverImpl
@@ -59,7 +58,6 @@ class ReceiverFactory {
                 receiver.handleEvent(RtpPayloadTypeAddedEvent(it))
             }
             headerExtensions.forEach {
-                receiver.handleEvent(RtpExtensionAddedEvent(it))
                 streamInformationStore.addRtpExtensionMapping(it)
             }
             ssrcAssociations.forEach {

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/SenderFactory.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/SenderFactory.kt
@@ -25,6 +25,7 @@ import org.jitsi.nlj.SsrcAssociationEvent
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtp.RtpExtension
+import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.test_utils.SourceAssociation
 import org.jitsi.test_utils.SrtpData
 import org.jitsi.utils.MediaType
@@ -42,12 +43,14 @@ class SenderFactory {
             headerExtensions: List<RtpExtension>,
             ssrcAssociations: List<SourceAssociation>
         ): RtpSender {
+            val streamInformationStore = StreamInformationStoreImpl()
             val sender = RtpSenderImpl(
                 Random().nextLong().toString(),
                 null,
                 RtcpEventNotifier(),
                 executor,
-                backgroundExecutor
+                backgroundExecutor,
+                streamInformationStore
             )
             sender.setSrtpTransformers(SrtpTransformerFactory.createSrtpTransformers(srtpData))
 
@@ -56,6 +59,7 @@ class SenderFactory {
             }
             headerExtensions.forEach {
                 sender.handleEvent(RtpExtensionAddedEvent(it))
+                streamInformationStore.addRtpExtensionMapping(it)
             }
             ssrcAssociations.forEach {
                 sender.handleEvent(SsrcAssociationEvent(it.primarySsrc, it.secondarySsrc, it.associationType))

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/SenderFactory.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/SenderFactory.kt
@@ -16,7 +16,6 @@
 
 package org.jitsi.nlj.module_tests
 
-import org.jitsi.nlj.RtpExtensionAddedEvent
 import org.jitsi.nlj.RtpPayloadTypeAddedEvent
 import org.jitsi.nlj.RtpSender
 import org.jitsi.nlj.RtpSenderImpl
@@ -58,7 +57,6 @@ class SenderFactory {
                 sender.handleEvent(RtpPayloadTypeAddedEvent(it))
             }
             headerExtensions.forEach {
-                sender.handleEvent(RtpExtensionAddedEvent(it))
                 streamInformationStore.addRtpExtensionMapping(it)
             }
             ssrcAssociations.forEach {


### PR DESCRIPTION
@bgrozev this stems from the discussions in the PR [here](https://github.com/jitsi/jitsi-media-transform/pull/100) about the duplicate event handling code.  Initially I was planning on delaying that, but once you pointed out we have the RTX issue with Octo (in the bridge PR [here](https://github.com/jitsi/jitsi-videobridge/pull/863) I thought we should just fix it.  Consider this a proof of concept: I didn't port all the data from all of the events yet, I just did the RTP extension events to see how it felt.  Any thoughts?