### PR TITLE
Separate a SecondaryPayloadType into its own type

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
+++ b/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
@@ -123,12 +123,21 @@ class H264PayloadType(
     rtcpFeedbackSet: RtcpFeedbackSet = CopyOnWriteArraySet()
 ) : VideoPayloadType(pt, PayloadTypeEncoding.H264, parameters = parameters, rtcpFeedbackSet = rtcpFeedbackSet)
 
+interface SecondaryPayloadType {
+    /**
+     * The primary payload type ID with which this secondary payload
+     * type is associated
+     */
+    val associatedPayloadType: Int
+}
+
 abstract class SecondaryVideoPayloadType(
     pt: Byte,
     encoding: PayloadTypeEncoding,
     parameters: PayloadTypeParams
-) : VideoPayloadType(pt, encoding, parameters = parameters) {
-    val associatedPayloadType: Int = parameters["apt"]?.toInt() ?: error("SecondaryVideoPayloadType must contain 'apt'")
+) : SecondaryPayloadType, VideoPayloadType(pt, encoding, parameters = parameters) {
+    override val associatedPayloadType: Int =
+        parameters["apt"]?.toInt() ?: error("SecondaryVideoPayloadType must contain 'apt'")
 }
 
 class RtxPayloadType(

--- a/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
+++ b/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
@@ -123,13 +123,18 @@ class H264PayloadType(
     rtcpFeedbackSet: RtcpFeedbackSet = CopyOnWriteArraySet()
 ) : VideoPayloadType(pt, PayloadTypeEncoding.H264, parameters = parameters, rtcpFeedbackSet = rtcpFeedbackSet)
 
+abstract class SecondaryVideoPayloadType(
+    pt: Byte,
+    encoding: PayloadTypeEncoding,
+    parameters: PayloadTypeParams
+) : VideoPayloadType(pt, encoding, parameters = parameters) {
+    val associatedPayloadType: Int = parameters["apt"]?.toInt() ?: error("SecondaryVideoPayloadType must contain 'apt'")
+}
+
 class RtxPayloadType(
     pt: Byte,
     parameters: PayloadTypeParams = ConcurrentHashMap()
-) : VideoPayloadType(pt, PayloadTypeEncoding.RTX, parameters = parameters) {
-    val associatedPayloadType: Int?
-        get() = parameters["apt"]?.toInt()
-}
+) : SecondaryVideoPayloadType(pt, PayloadTypeEncoding.RTX, parameters = parameters)
 
 abstract class AudioPayloadType(
     pt: Byte,

--- a/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
+++ b/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
@@ -123,27 +123,13 @@ class H264PayloadType(
     rtcpFeedbackSet: RtcpFeedbackSet = CopyOnWriteArraySet()
 ) : VideoPayloadType(pt, PayloadTypeEncoding.H264, parameters = parameters, rtcpFeedbackSet = rtcpFeedbackSet)
 
-interface SecondaryPayloadType {
-    /**
-     * The primary payload type ID with which this secondary payload
-     * type is associated
-     */
-    val associatedPayloadType: Int
-}
-
-abstract class SecondaryVideoPayloadType(
-    pt: Byte,
-    encoding: PayloadTypeEncoding,
-    parameters: PayloadTypeParams
-) : SecondaryPayloadType, VideoPayloadType(pt, encoding, parameters = parameters) {
-    override val associatedPayloadType: Int =
-        parameters["apt"]?.toInt() ?: error("SecondaryVideoPayloadType must contain 'apt'")
-}
-
 class RtxPayloadType(
     pt: Byte,
     parameters: PayloadTypeParams = ConcurrentHashMap()
-) : SecondaryVideoPayloadType(pt, PayloadTypeEncoding.RTX, parameters = parameters)
+) : VideoPayloadType(pt, PayloadTypeEncoding.RTX, parameters = parameters) {
+    val associatedPayloadType: Int =
+        parameters["apt"]?.toInt() ?: error("RtxPayloadType must contain 'apt'")
+}
 
 abstract class AudioPayloadType(
     pt: Byte,

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSenderTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSenderTest.kt
@@ -67,7 +67,7 @@ class RetransmissionSenderTest : ShouldSpec() {
 
         // Setup: add the rtx payload type and the rtx ssrc association
         streamInformationStore.addRtpPayloadType(
-                RtxPayloadType(rtxPayloadType.toByte(), mapOf("apt" to originalPayloadType.toString()))
+            RtxPayloadType(rtxPayloadType.toByte(), mapOf("apt" to originalPayloadType.toString()))
         )
         retransmissionSender.handleEvent(SsrcAssociationEvent(originalSsrc, rtxSsrc, SsrcAssociationType.RTX))
     }


### PR DESCRIPTION
The goal here was to make bugs like the RTX one fixed in https://github.com/jitsi/jitsi-media-transform/pull/107 less likely by strongly typing where we store payload types.  Whereas before we held a `Map<Int, Int>` and it was easy to mix up the original payload type ID and the RTX payload type ID, this changes the way we hold them and uses the `RtxPayloadType` directly in an effort to make mistakes like that less likely.  (It also made the logic to update the payload types in `RtxHandler` and `RetransmissionSender` simpler).

Will need to be rebased after https://github.com/jitsi/jitsi-media-transform/pull/109 is merged.