### PR TITLE
new context logger

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -81,7 +81,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
     streamInformationStore: ReadOnlyStreamInformationStore,
     logLevelDelegate: Logger? = null
 ) : RtpReceiver() {
-    private val logContext = LogContext("$id rx")
+    private val logContext = LogContext("ep $id RX")
     private val logger = getLoggerWithContext(this.javaClass, logLevelDelegate, logContext)
     private var running: Boolean = true
     private val inputTreeRoot: Node

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -43,11 +43,11 @@ import org.jitsi.nlj.transform.node.incoming.VideoParser
 import org.jitsi.nlj.transform.node.incoming.Vp8Parser
 import org.jitsi.nlj.transform.packetPath
 import org.jitsi.nlj.transform.pipeline
+import org.jitsi.nlj.util.LogContext
 import org.jitsi.nlj.util.PacketInfoQueue
 import org.jitsi.nlj.util.PacketPredicate
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
-import org.jitsi.nlj.util.cdebug
-import org.jitsi.nlj.util.getLogger
+import org.jitsi.nlj.util.getLoggerWithContext
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.util.RTCPUtils
 import org.jitsi.utils.logging.Logger
@@ -81,14 +81,15 @@ class RtpReceiverImpl @JvmOverloads constructor(
     streamInformationStore: ReadOnlyStreamInformationStore,
     logLevelDelegate: Logger? = null
 ) : RtpReceiver() {
-    private val logger = getLogger(classLogger, logLevelDelegate)
+    private val logContext = LogContext("$id rx")
+    private val logger = getLoggerWithContext(this.javaClass, logLevelDelegate, logContext)
     private var running: Boolean = true
     private val inputTreeRoot: Node
     private val incomingPacketQueue =
             PacketInfoQueue("rtp-receiver-incoming-packet-queue", executor, this::handleIncomingPacket)
     private val srtpDecryptWrapper = SrtpTransformerNode("SRTP Decrypt node")
     private val srtcpDecryptWrapper = SrtpTransformerNode("SRTCP Decrypt node")
-    private val tccGenerator = TccGeneratorNode(id, rtcpSender, streamInformationStore)
+    private val tccGenerator = TccGeneratorNode(id, rtcpSender, streamInformationStore, logContext = logContext)
     private val audioLevelReader = AudioLevelReader(streamInformationStore)
     private val silenceDiscarder = SilenceDiscarder(true)
     private val statsTracker = IncomingStatisticsTracker(streamInformationStore)

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -88,13 +88,13 @@ class RtpReceiverImpl @JvmOverloads constructor(
             PacketInfoQueue("rtp-receiver-incoming-packet-queue", executor, this::handleIncomingPacket)
     private val srtpDecryptWrapper = SrtpTransformerNode("SRTP Decrypt node")
     private val srtcpDecryptWrapper = SrtpTransformerNode("SRTCP Decrypt node")
-    private val tccGenerator = TccGeneratorNode(rtcpSender, streamInformationStore)
+    private val tccGenerator = TccGeneratorNode(id, rtcpSender, streamInformationStore)
     private val audioLevelReader = AudioLevelReader(streamInformationStore)
     private val silenceDiscarder = SilenceDiscarder(true)
     private val statsTracker = IncomingStatisticsTracker(streamInformationStore)
     private val packetStreamStats = PacketStreamStatsNode()
     private val rtcpRrGenerator = RtcpRrGenerator(backgroundExecutor, rtcpSender, statsTracker)
-    private val rtcpTermination = RtcpTermination(rtcpEventNotifier)
+    private val rtcpTermination = RtcpTermination(id, rtcpEventNotifier)
 
     companion object {
         private val classLogger: Logger = Logger.getLogger(this::class.java)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -35,6 +35,7 @@ import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.RtcpFbNackPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket
 
 class RtcpTermination(
+    private val id: String,
     private val rtcpEventNotifier: RtcpEventNotifier
 ) : TransformerNode("RTCP termination") {
     private var packetReceiveCounts = mutableMapOf<String, Int>()
@@ -68,7 +69,7 @@ class RtcpTermination(
                     // notifyRtcpReceived below
                 }
                 else -> {
-                    logger.cinfo { "TODO: not yet handling RTCP packet of type ${rtcpPacket.javaClass}" }
+                    logger.cinfo { "TODO: $id not yet handling RTCP packet of type ${rtcpPacket.javaClass}" }
                 }
             }
             // TODO: keep an eye on if anything in here takes a while it could slow the packet pipeline down

--- a/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.util
+
+import org.jitsi.utils.logging.Logger
+
+class ContextLogger(private val context: String) {
+    private val logger = Logger.getLogger(context)
+
+    val isInfoEnabled: Boolean
+        get() = logger.isInfoEnabled
+
+    val isDebugEnabled: Boolean
+        get() = logger.isDebugEnabled
+
+    val isWarnEnabled: Boolean
+        get() = logger.isWarnEnabled
+
+    val isTraceEnabled: Boolean
+        get() = logger.isTraceEnabled
+
+    fun createSubcontext(context: String): ContextLogger {
+        return ContextLogger("${this.context} $context")
+    }
+
+    fun error(msg: String) = logger.error(msg)
+
+    fun warn(msg: String) = logger.warn(msg)
+
+    fun info(msg: String) = logger.info(msg)
+
+    fun debug(msg: String) = logger.debug(msg)
+
+    fun trace(msg: String) = logger.trace(msg)
+
+    inline fun cinfo(msg: () -> String) {
+        if (isInfoEnabled) {
+            info(msg())
+        }
+    }
+
+    inline fun cdebug(msg: () -> String) {
+        if (isDebugEnabled) {
+            this.debug(msg())
+        }
+    }
+
+    inline fun cwarn(msg: () -> String) {
+        if (isWarnEnabled) {
+            warn(msg())
+        }
+    }
+
+    inline fun cerror(msg: () -> String) {
+        error(msg())
+    }
+
+    inline fun ctrace(msg: () -> String) {
+        if (isTraceEnabled) {
+            trace(msg())
+        }
+    }
+}

--- a/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
@@ -20,9 +20,10 @@ import org.jitsi.utils.logging.Logger
 
 class ContextLogger(
     name: String,
+    levelDelegate: Logger? = null,
     private val context: LogContext
 ) {
-    private val logger = Logger.getLogger(name)
+    private val logger = getLogger(name, levelDelegate)
 
     val isInfoEnabled: Boolean
         get() = logger.isInfoEnabled

--- a/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
@@ -84,13 +84,11 @@ class ContextLogger(
 data class LogContext(
     val prefix: String
 ) {
-    override fun toString(): String = prefix
-
-    fun createSubContext(newContext: LogContext) =
-        LogContext("$prefix ${newContext.prefix}")
+    private val formattedPrefix = "[$prefix]"
+    override fun toString(): String = formattedPrefix
 
     fun createSubContext(newPrefix: String) =
-        LogContext("$prefix $newPrefix")
+        LogContext("$prefix-$newPrefix")
 
     companion object {
         val EMPTY = LogContext("")

--- a/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ContextLogger.kt
@@ -18,8 +18,11 @@ package org.jitsi.nlj.util
 
 import org.jitsi.utils.logging.Logger
 
-class ContextLogger(private val context: String) {
-    private val logger = Logger.getLogger(context)
+class ContextLogger(
+    name: String,
+    private val context: LogContext
+) {
+    private val logger = Logger.getLogger(name)
 
     val isInfoEnabled: Boolean
         get() = logger.isInfoEnabled
@@ -33,19 +36,15 @@ class ContextLogger(private val context: String) {
     val isTraceEnabled: Boolean
         get() = logger.isTraceEnabled
 
-    fun createSubcontext(context: String): ContextLogger {
-        return ContextLogger("${this.context} $context")
-    }
+    fun error(msg: String) = logger.error("$context $msg")
 
-    fun error(msg: String) = logger.error(msg)
+    fun warn(msg: String) = logger.warn("$context $msg")
 
-    fun warn(msg: String) = logger.warn(msg)
+    fun info(msg: String) = logger.info("$context $msg")
 
-    fun info(msg: String) = logger.info(msg)
+    fun debug(msg: String) = logger.debug("$context $msg")
 
-    fun debug(msg: String) = logger.debug(msg)
-
-    fun trace(msg: String) = logger.trace(msg)
+    fun trace(msg: String) = logger.trace("$context $msg")
 
     inline fun cinfo(msg: () -> String) {
         if (isInfoEnabled) {
@@ -73,5 +72,26 @@ class ContextLogger(private val context: String) {
         if (isTraceEnabled) {
             trace(msg())
         }
+    }
+}
+
+/**
+ * A [LogContext] contains information which will be logged with every
+ * statement.  For now it just includes a prefix, but could be extended
+ * to include values of variables contained in a map.
+ */
+data class LogContext(
+    val prefix: String
+) {
+    override fun toString(): String = prefix
+
+    fun createSubContext(newContext: LogContext) =
+        LogContext("$prefix ${newContext.prefix}")
+
+    fun createSubContext(newPrefix: String) =
+        LogContext("$prefix $newPrefix")
+
+    companion object {
+        val EMPTY = LogContext("")
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/util/LoggerExtensions.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/LoggerExtensions.kt
@@ -51,7 +51,11 @@ fun <T : Any> getLogger(forClass: Class<T>): Logger {
 }
 
 fun <T : Any> getLoggerWithContext(forClass: Class<T>, context: LogContext): ContextLogger {
-    return ContextLogger(forClass.name, context)
+    return ContextLogger(forClass.name, context = context)
+}
+
+fun <T : Any> getLoggerWithContext(forClass: Class<T>, levelDelegate: Logger?, context: LogContext): ContextLogger {
+    return ContextLogger(forClass.name, levelDelegate, context)
 }
 
 /**
@@ -62,6 +66,14 @@ fun <T : Any> getLogger(forClass: Class<T>, levelDelegate: Logger?): Logger {
         getLogger(getLogger(forClass), levelDelegate)
     } else {
         getLogger(forClass)
+    }
+}
+
+fun getLogger(name: String, levelDelegate: Logger?): Logger {
+    return if (levelDelegate != null) {
+        getLogger(Logger.getLogger(name), levelDelegate)
+    } else {
+        Logger.getLogger(name)
     }
 }
 

--- a/src/main/kotlin/org/jitsi/nlj/util/LoggerExtensions.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/LoggerExtensions.kt
@@ -50,6 +50,10 @@ fun <T : Any> getLogger(forClass: Class<T>): Logger {
     return Logger.getLogger(forClass.name)
 }
 
+fun <T : Any> getLoggerWithContext(forClass: Class<T>, context: LogContext): ContextLogger {
+    return ContextLogger(forClass.name, context)
+}
+
 /**
  * Create a new logger which delegates its level to another logger
  */

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
@@ -37,7 +37,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
         super.beforeSpec(spec)
         doNothing().whenever(streamInformationStore).onRtpExtensionMapping(
                 eq(RtpExtensionType.TRANSPORT_CC), setTccExtId.capture())
-        tccGenerator = TccGeneratorNode(onTccReady, streamInformationStore, clock)
+        tccGenerator = TccGeneratorNode("id", onTccReady, streamInformationStore, clock)
         setTccExtId.firstValue(tccExtensionId)
     }
 


### PR DESCRIPTION
playing with this to address what we talked about and curious if you had any thoughts on the approach.  i've created a `LogContext` and and `ContextLogger` which wraps a jitsi `Logger` and adds a prefix.  `LogContext` makes it easy to 'cascade' by creating a sub-context from an existing one.  i made some quick changes in RtpReceiverImpl and TCC Generator to use them. an example output line (once we clean out printing the full classname, see note below):

`JVB 2019-08-20 20:36:43.811 FINE: [82] [ep a70c1063 RX-TCC Generator] sent TCC packet with seq num 68`

i had to continue to use the classname for the logger name, as we rely on that to individually set the levels.  the plan would be to change the log formatter to not print the classname and we'd just rely on the context prefix instead.  or maybe we can come up with something clever to support both (though i don't see any reason why we couldn't move everything over to context logger).  we do have an extra string concat per log here, which is a bummer.  maybe there's a way that could be fixed.  