### PR TITLE
manage receive SSRCs

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/Event.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Event.kt
@@ -20,7 +20,6 @@ import org.jitsi_modified.impl.neomedia.rtp.MediaStreamTrackDesc
 
 interface Event
 
-class ReceiveSsrcAddedEvent(val ssrc: Long) : Event
 class ReceiveSsrcRemovedEvent(val ssrc: Long) : Event
 
 class SetMediaStreamTracksEvent(val mediaStreamTrackDescs: Array<MediaStreamTrackDesc>) : Event

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -164,14 +164,11 @@ class Transceiver(
     fun addReceiveSsrc(ssrc: Long, mediaType: MediaType) {
         logger.cdebug { "${hashCode()} adding receive ssrc $ssrc of type $mediaType" }
         streamInformationStore.addReceiveSsrc(ssrc, mediaType)
-        rtpReceiver.handleEvent(ReceiveSsrcAddedEvent(ssrc))
-        // TODO: fire events to rtp sender as well
     }
 
     fun removeReceiveSsrc(ssrc: Long) {
         logger.cinfo { "Transceiver ${hashCode()} removing receive ssrc $ssrc" }
         streamInformationStore.removeReceiveSsrc(ssrc)
-        rtpReceiver.handleEvent(ReceiveSsrcRemovedEvent(ssrc))
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -39,7 +39,6 @@ import org.jitsi_modified.impl.neomedia.rtp.MediaStreamTrackDesc
 import org.jitsi_modified.impl.neomedia.rtp.TransportCCEngine
 import org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation.BandwidthEstimatorImpl
 import org.jitsi_modified.service.neomedia.rtp.BandwidthEstimator
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 
@@ -70,7 +69,6 @@ class Transceiver(
     logLevelDelegate: Logger? = null
 ) : Stoppable, NodeStatsProducer {
     private val logger = getLogger(this.javaClass, logLevelDelegate)
-    private val receiveSsrcs = ConcurrentHashMap.newKeySet<Long>()
     val packetIOActivity = PacketIOActivity()
     private val endpointConnectionStats = EndpointConnectionStats()
     private val streamInformationStore = StreamInformationStoreImpl()
@@ -163,16 +161,16 @@ class Transceiver(
         rtpSender.onOutgoingPacket(outgoingPacketHandler)
     }
 
-    fun addReceiveSsrc(ssrc: Long) {
-        logger.cdebug { "${hashCode()} adding receive ssrc $ssrc" }
-        receiveSsrcs.add(ssrc)
+    fun addReceiveSsrc(ssrc: Long, mediaType: MediaType) {
+        logger.cdebug { "${hashCode()} adding receive ssrc $ssrc of type $mediaType" }
+        streamInformationStore.addReceiveSsrc(ssrc, mediaType)
         rtpReceiver.handleEvent(ReceiveSsrcAddedEvent(ssrc))
         // TODO: fire events to rtp sender as well
     }
 
     fun removeReceiveSsrc(ssrc: Long) {
         logger.cinfo { "Transceiver ${hashCode()} removing receive ssrc $ssrc" }
-        receiveSsrcs.remove(ssrc)
+        streamInformationStore.removeReceiveSsrc(ssrc)
         rtpReceiver.handleEvent(ReceiveSsrcRemovedEvent(ssrc))
     }
 
@@ -185,7 +183,7 @@ class Transceiver(
         rtpReceiver.handleEvent(localSsrcSetEvent)
     }
 
-    fun receivesSsrc(ssrc: Long): Boolean = receiveSsrcs.contains(ssrc)
+    fun receivesSsrc(ssrc: Long): Boolean = streamInformationStore.receiveSsrcs.contains(ssrc)
 
     fun setMediaStreamTracks(mediaStreamTracks: Array<MediaStreamTrackDesc>): Boolean {
         logger.cdebug { "$id setting media stream tracks: ${mediaStreamTracks.joinToString()}" }
@@ -260,7 +258,6 @@ class Transceiver(
     override fun getNodeStats(): NodeStatsBlock {
         return NodeStatsBlock("Transceiver $id").apply {
             addBlock(streamInformationStore.getNodeStats())
-            addString("receiveSsrcs", receiveSsrcs.toString())
             addBlock(mediaStreamTracks.getNodeStats())
             addString("endpointConnectionStats", endpointConnectionStats.getSnapshot().toString())
             addBlock(bandwidthEstimator.getNodeStats())

--- a/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
@@ -1,18 +1,41 @@
 package org.jitsi.nlj.util
 
+import org.jitsi.nlj.stats.NodeStatsBlock
+import org.jitsi.nlj.transform.NodeStatsProducer
 import org.jitsi.utils.MediaType
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
 
-class ReceiveSsrcStore(private val ssrcAssociationStore: SsrcAssociationStore) {
+class ReceiveSsrcStore(
+    private val ssrcAssociationStore: SsrcAssociationStore
+) : NodeStatsProducer {
+    // NOTE: to enable efficient lookup for various use cases, we store
+    // different 'views' of the receive SSRCs in multiple data structures
+    // (below).  Updates to these data structures do not happen atomically,
+    // so it's possible the view across them may be inconsistent while changes
+    // are propagating.  We don't currently have code that cares about this,
+    // so it's done this way to avoid having to synchronize updates and access
+    // across all of them.
+    /**
+     * All signaled receive SSRCs
+     */
+    val receiveSsrcs: MutableSet<Long> = CopyOnWriteArraySet()
+
+    /**
+     * All receive SSRCs indexed by their media type
+     */
     private val receiveSsrcsByMediaType: MutableMap<MediaType, MutableSet<Long>> =
         ConcurrentHashMap()
 
     /**
-     * 'Primary' media SSRCs (excludes things like RTX). Note that
-     * all SSRCs added via [addReceiveSsrc]
+     * 'Primary' receive media SSRCs (excludes things like RTX)
      */
-    val mediaSsrcs = mutableSetOf<Long>()
-    val videoSsrcs = mutableSetOf<Long>()
+    val primaryMediaSsrcs: MutableSet<Long> = CopyOnWriteArraySet()
+
+    /**
+     * 'Primary' *video* SSRCs
+     */
+    val primaryVideoSsrcs: MutableSet<Long> = CopyOnWriteArraySet()
 
     init {
         ssrcAssociationStore.onAssociation(this::onSsrcAssociation)
@@ -20,26 +43,35 @@ class ReceiveSsrcStore(private val ssrcAssociationStore: SsrcAssociationStore) {
 
     fun addReceiveSsrc(ssrc: Long, mediaType: MediaType) {
         receiveSsrcsByMediaType.getOrPut(mediaType, { mutableSetOf() }).add(ssrc)
+        receiveSsrcs.add(ssrc)
         if (ssrcAssociationStore.isPrimarySsrc(ssrc)) {
-            mediaSsrcs.add(ssrc)
+            primaryMediaSsrcs.add(ssrc)
             if (mediaType == MediaType.VIDEO) {
-                videoSsrcs.add(ssrc)
+                primaryVideoSsrcs.add(ssrc)
             }
         }
     }
 
     fun removeReceiveSsrc(ssrc: Long) {
+        receiveSsrcs.remove(ssrc)
         receiveSsrcsByMediaType.values.forEach { it.remove(ssrc) }
+        primaryMediaSsrcs.remove(ssrc)
+        primaryVideoSsrcs.remove(ssrc)
     }
 
+    /**
+     * Handle new [SsrcAssociation]s
+     */
     private fun onSsrcAssociation(ssrcAssociation: SsrcAssociation) {
-        // We assume an association only involves SSRCs of the same media type
-        val mediaType = receiveSsrcsByMediaType.entries
-            .find { it.value.contains(ssrcAssociation.primarySsrc) }?.key ?: return
+        // Secondary SSRCs in associations shouldn't be considered
+        // primary media or video SSRCs
+        primaryVideoSsrcs.remove(ssrcAssociation.secondarySsrc)
+        primaryMediaSsrcs.remove(ssrcAssociation.secondarySsrc)
+    }
 
-        if (mediaType == MediaType.VIDEO) {
-            videoSsrcs.remove(ssrcAssociation.secondarySsrc)
-        }
-        mediaSsrcs.remove(ssrcAssociation.secondarySsrc)
+    override fun getNodeStats(): NodeStatsBlock = NodeStatsBlock("Receive SSRC store").apply {
+        addString("Receive SSRCs", receiveSsrcsByMediaType.toString())
+        addString("Primary media SSRCs", primaryMediaSsrcs.toString())
+        addString("Primary video SSRCs", primaryVideoSsrcs.toString())
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
@@ -1,0 +1,45 @@
+package org.jitsi.nlj.util
+
+import org.jitsi.utils.MediaType
+import java.util.concurrent.ConcurrentHashMap
+
+class ReceiveSsrcStore(private val ssrcAssociationStore: SsrcAssociationStore) {
+    private val receiveSsrcsByMediaType: MutableMap<MediaType, MutableSet<Long>> =
+        ConcurrentHashMap()
+
+    /**
+     * 'Primary' media SSRCs (excludes things like RTX). Note that
+     * all SSRCs added via [addReceiveSsrc]
+     */
+    val mediaSsrcs = mutableSetOf<Long>()
+    val videoSsrcs = mutableSetOf<Long>()
+
+    init {
+        ssrcAssociationStore.onAssociation(this::onSsrcAssociation)
+    }
+
+    fun addReceiveSsrc(ssrc: Long, mediaType: MediaType) {
+        receiveSsrcsByMediaType.getOrPut(mediaType, { mutableSetOf() }).add(ssrc)
+        if (ssrcAssociationStore.isPrimarySsrc(ssrc)) {
+            mediaSsrcs.add(ssrc)
+            if (mediaType == MediaType.VIDEO) {
+                videoSsrcs.add(ssrc)
+            }
+        }
+    }
+
+    fun removeReceiveSsrc(ssrc: Long) {
+        receiveSsrcsByMediaType.values.forEach { it.remove(ssrc) }
+    }
+
+    private fun onSsrcAssociation(ssrcAssociation: SsrcAssociation) {
+        // We assume an association only involves SSRCs of the same media type
+        val mediaType = receiveSsrcsByMediaType.entries
+            .find { it.value.contains(ssrcAssociation.primarySsrc) }?.key ?: return
+
+        if (mediaType == MediaType.VIDEO) {
+            videoSsrcs.remove(ssrcAssociation.secondarySsrc)
+        }
+        mediaSsrcs.remove(ssrcAssociation.secondarySsrc)
+    }
+}

--- a/src/main/kotlin/org/jitsi/nlj/util/SsrcAssociationStore.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/SsrcAssociationStore.kt
@@ -48,6 +48,8 @@ class SsrcAssociationStore(
     fun getSecondarySsrc(primarySsrc: Long, associationType: SsrcAssociationType): Long? =
         ssrcAssociationsByPrimarySsrc[primarySsrc]?.find { it.type == associationType }?.secondarySsrc
 
+    fun isPrimarySsrc(ssrc: Long): Boolean = ssrcAssociationsByPrimarySsrc.containsKey(ssrc)
+
     override fun getNodeStats(): NodeStatsBlock = NodeStatsBlock(name).apply {
         addString("SSRC associations", ssrcAssociations.toString())
     }

--- a/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
@@ -51,13 +51,24 @@ interface ReadOnlyStreamInformationStore {
     fun getLocalPrimarySsrc(secondarySsrc: Long): Long?
     fun getRemoteSecondarySsrc(primarySsrc: Long, associationType: SsrcAssociationType): Long?
 
+    /**
+     * All signaled receive SSRCs
+     */
     val receiveSsrcs: Set<Long>
+
+    /**
+     * A list of all primary media (audio and video) SSRCs for which the
+     * endpoint associated with this stream information store sends video
+     * (does not include things like RTX)
+     */
+    val primaryMediaSsrcs: Set<Long>
+
     /**
      * A list of all primary video SSRCs for which the endpoint associated
      * with this stream information store sends video (does not include
      * RTX)
      */
-    val videoSsrcs: Set<Long>
+    val primaryVideoSsrcs: Set<Long>
 
     val supportsPli: Boolean
     val supportsFir: Boolean
@@ -99,7 +110,9 @@ class StreamInformationStoreImpl : StreamInformationStore, NodeStatsProducer {
     private val receiveSsrcStore = ReceiveSsrcStore(localSsrcAssociations)
     override val receiveSsrcs: Set<Long>
         get() = receiveSsrcStore.receiveSsrcs
-    override val videoSsrcs: Set<Long>
+    override val primaryMediaSsrcs: Set<Long>
+        get() = receiveSsrcStore.primaryMediaSsrcs
+    override val primaryVideoSsrcs: Set<Long>
         get() = receiveSsrcStore.primaryVideoSsrcs
 
     override var supportsPli: Boolean = false


### PR DESCRIPTION
this moves the management of receive ssrcs into the stream store (`ReceiveSsrcStore` within the stream store).  this has 2 goals:
1) centralize the management of these receive ssrcs as we've done with the other stream data
2) centralize the somewhat complex logic of determining primary media and video ssrcs as there exists code that relies on getting precisely that information (tcc feedback packets need to use any primary media ssrcs, pre-emptive keyframes will need to use specifically a primary _video_ ssrc).