### PR TITLE
Fix reversed logic disabling send-side replay protection.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/srtp/SrtpUtil.kt
+++ b/src/main/kotlin/org/jitsi/nlj/srtp/SrtpUtil.kt
@@ -141,9 +141,10 @@ class SrtpUtil {
                 srtpProfileInformation.cipherSaltLength
             )
 
-            /* To support RetransmissionSender.retransmitPlain, we need to allow send-side SRTP replay. */
-            /* TODO: enable this only in cases where we actually need to use retransmitPlain? */
-            srtpPolicy.isSendReplayEnabled = true
+            /* To support RetransmissionSender.retransmitPlain, we need to disable
+               send-side SRTP replay protection. */
+            /* TODO: disable this only in cases where we actually need to use retransmitPlain? */
+            srtpPolicy.isSendReplayEnabled = false
 
             val clientSrtpContextFactory = SrtpContextFactory(
                 tlsRole == TlsRole.CLIENT,


### PR DESCRIPTION
We need to *disable* send-side replay protection — enabled is the default.