### PR TITLE
Use ${kotlin.version} as version of kotlin-reflect.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
-            <version>1.2.50</version>
+            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
So it uses the same version as the rest of the kotlin toolchain.

Eliminates some warnings about incompatible versions.