### PR TITLE
Import remotebandwidthestimation to jitsi-media-transform

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
@@ -16,13 +16,10 @@
 package org.jitsi_modified.impl.neomedia.rtp;
 
 import org.jetbrains.annotations.*;
-import org.jitsi.impl.neomedia.rtp.remotebitrateestimator.*;
-import org.jitsi.impl.neomedia.transform.*;
+import org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator.*;
 import org.jitsi.nlj.rtcp.*;
 import org.jitsi.rtp.rtcp.*;
-import org.jitsi.rtp.rtcp.rtcpfb.*;
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.*;
-import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging.*;
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
@@ -85,7 +85,7 @@ public class TransportCCEngine
      * Local time to map to the reference time of the remote clock. This is used
      * to rebase the arrival times in the TCC packets to a meaningful time base
      * (that of the sender). This is technically not necessary and it's done for
-     * convinience.
+     * convenience.
      */
     private long localReferenceTimeMs = -1;
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
@@ -21,7 +21,8 @@ import org.jitsi.nlj.rtcp.*;
 import org.jitsi.rtp.rtcp.*;
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.*;
 import org.jitsi.utils.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging2.*;
 
 import java.util.*;
 
@@ -47,29 +48,14 @@ public class TransportCCEngine
     private static final int MAX_OUTGOING_PACKETS_HISTORY = 1000;
 
     /**
-     * The {@link Logger} used by the {@link TransportCCEngine} class and its
-     * instances for logging output.
+     * The {@link Logger} used by this instance for logging output.
      */
-    private static final Logger logger
-        = Logger.getLogger(TransportCCEngine.class);
-
-    /**
-     * The {@link TimeSeriesLogger} to be used by this instance to print time
-     * series.
-     */
-    private static final TimeSeriesLogger timeSeriesLogger
-        = TimeSeriesLogger.getTimeSeriesLogger(TransportCCEngine.class);
+    private final Logger logger;
 
     /**
      * Used to synchronize access to {@link #sentPacketDetails}.
      */
     private final Object sentPacketsSyncRoot = new Object();
-
-    /**
-     * The {@link DiagnosticContext} to be used by this instance when printing
-     * diagnostic information.
-     */
-    private final DiagnosticContext diagnosticContext;
 
     /**
      * The reference time of the remote clock. This is used to rebase the
@@ -107,12 +93,13 @@ public class TransportCCEngine
      */
     public TransportCCEngine(
             @NotNull DiagnosticContext diagnosticContext,
-            RemoteBitrateObserver remoteBitrateObserver)
+            RemoteBitrateObserver remoteBitrateObserver,
+            @NotNull Logger parentLogger)
     {
-        this.diagnosticContext = diagnosticContext;
+        logger = parentLogger.createChildLogger(getClass().getName());
         this.remoteBitrateObserver = remoteBitrateObserver;
         bitrateEstimatorAbsSendTime
-            = new RemoteBitrateEstimatorAbsSendTime(this, diagnosticContext);
+            = new RemoteBitrateEstimatorAbsSendTime(this, diagnosticContext, logger);
     }
 
     /**

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+import org.jitsi.service.neomedia.rtp.*;
+import org.jetbrains.annotations.*;
+import org.jitsi.utils.logging.*;
+
+/**
+ * A rate control implementation based on additive increases of bitrate when no
+ * over-use is detected and multiplicative decreases when over-uses are
+ * detected. When we think the available bandwidth has changes or is unknown, we
+ * will switch to a "slow-start mode" where we increase multiplicatively.
+ *
+ * webrtc/modules/remote_bitrate_estimator/aimd_rate_control.cc
+ * webrtc/modules/remote_bitrate_estimator/aimd_rate_control.h
+ *
+ * @author Lyubomir Marinov
+ */
+class AimdRateControl
+{
+    /**
+     * The <tt>TimeSeriesLogger</tt> used by the
+     * <tt>RemoteBitrateEstimatorAbsSendTime</tt> class and its instances for
+     * logging output.
+     */
+    private static final TimeSeriesLogger logger
+        = TimeSeriesLogger.getTimeSeriesLogger(AimdRateControl.class);
+
+    private static final int kDefaultRttMs = 200;
+
+    private static final long kInitializationTimeMs = 5000;
+
+    private static final long kLogIntervalMs = 1000;
+
+    private static final long kMaxFeedbackIntervalMs = 1000;
+
+    private static final long kMinFeedbackIntervalMs = 200;
+
+    private static final int kRtcpSize = 80;
+
+    private static final double kWithinIncomingBitrateHysteresis = 1.05;
+
+    private final DiagnosticContext diagnosticContext;
+
+    private float avgMaxBitrateKbps;
+
+    private float beta;
+
+    private boolean bitrateIsInitialized;
+
+    private long currentBitrateBps;
+
+    private final RateControlInput currentInput
+        = new RateControlInput(BandwidthUsage.kBwNormal, 0L, 0D);
+
+    private boolean inExperiment;
+
+    private long minConfiguredBitrateBps;
+
+    private RateControlRegion rateControlRegion;
+
+    private RateControlState rateControlState;
+
+    private long rtt;
+
+    private long timeFirstIncomingEstimate;
+
+    private long timeLastBitrateChange;
+
+    private long timeOfLastLog;
+
+    private boolean updated;
+
+    private float varMaxBitrateKbps;
+
+    public AimdRateControl(@NotNull DiagnosticContext diagnosticContext)
+    {
+        reset();
+        this.diagnosticContext = diagnosticContext;
+    }
+
+    private long additiveRateIncrease(
+            long nowMs,
+            long lastMs,
+            long responseTimeMs)
+    {
+        if (responseTimeMs <= 0)
+            throw new IllegalArgumentException("responseTimeMs");
+
+        double beta = 0.0;
+
+        if (lastMs > 0) {
+            beta
+                = Math.min((nowMs - lastMs) / (double) responseTimeMs, 1.0);
+            if (inExperiment)
+                beta /= 2.0;
+        }
+
+        double bitsPerFrame = (double) currentBitrateBps / 30.0;
+        double packetsPerFrame = Math.ceil(bitsPerFrame / (8.0 * 1200.0));
+        double avgPacketSizeBits = bitsPerFrame / packetsPerFrame;
+
+        return (long) Math.max(1000.0, beta * avgPacketSizeBits);
+    }
+
+    private long changeBitrate(
+            long currentBitrateBps,
+            long incomingBitrateBps,
+            long nowMs)
+    {
+        if (!updated)
+            return this.currentBitrateBps;
+        // An over-use should always trigger us to reduce the bitrate, even though
+        // we have not yet established our first estimate. By acting on the over-use,
+        // we will end up with a valid estimate.
+        if (!bitrateIsInitialized
+                && currentInput.bwState != BandwidthUsage.kBwOverusing)
+        {
+            return this.currentBitrateBps;
+        }
+
+        updated = false;
+        changeState(currentInput, nowMs);
+
+        // Calculated here because it's used in multiple places.
+        float incomingBitrateKbps = incomingBitrateBps / 1000.0F;
+        // Calculate the max bit rate std dev given the normalized variance and
+        // the current incoming bit rate.
+        float stdMaxBitRate
+            = (float) Math.sqrt(varMaxBitrateKbps * avgMaxBitrateKbps);
+
+        switch (rateControlState)
+        {
+        case kRcHold:
+            break;
+
+        case kRcIncrease:
+        {
+            if (avgMaxBitrateKbps >= 0F
+                    && incomingBitrateKbps
+                        > avgMaxBitrateKbps + 3F * stdMaxBitRate)
+            {
+                changeRegion(RateControlRegion.kRcMaxUnknown, nowMs);
+                avgMaxBitrateKbps = -1F;
+            }
+            if (rateControlRegion == RateControlRegion.kRcNearMax)
+            {
+                // Approximate the over-use estimator delay to 100 ms.
+                long responseTime = rtt + 100;
+                long additiveIncreaseBps
+                    = additiveRateIncrease(
+                            nowMs,
+                            timeLastBitrateChange,
+                            responseTime);
+
+                currentBitrateBps += additiveIncreaseBps;
+            }
+            else // kRcMaxUnknown || kRcAboveMax
+            {
+                long multiplicativeIncreaseBps
+                    = multiplicativeRateIncrease(
+                            nowMs,
+                            timeLastBitrateChange,
+                            currentBitrateBps);
+
+                currentBitrateBps += multiplicativeIncreaseBps;
+            }
+
+            timeLastBitrateChange = nowMs;
+            break;
+        }
+        case kRcDecrease:
+        {
+            bitrateIsInitialized = true;
+            if (incomingBitrateBps < minConfiguredBitrateBps)
+            {
+                currentBitrateBps = minConfiguredBitrateBps;
+            }
+            else
+            {
+                // Set bit rate to something slightly lower than max to get rid
+                // of any self-induced delay.
+                currentBitrateBps = (long) (beta * incomingBitrateBps + 0.5);
+                if (currentBitrateBps > this.currentBitrateBps)
+                {
+                    // Avoid increasing the rate when over-using.
+                    if (rateControlRegion != RateControlRegion.kRcMaxUnknown)
+                    {
+                        currentBitrateBps
+                            = (long) (beta * avgMaxBitrateKbps * 1000F + 0.5F);
+                    }
+                    currentBitrateBps
+                        = Math.min(currentBitrateBps, this.currentBitrateBps);
+                }
+                changeRegion(RateControlRegion.kRcNearMax, nowMs);
+
+                if (incomingBitrateKbps
+                        < avgMaxBitrateKbps - 3F * stdMaxBitRate)
+                {
+                    avgMaxBitrateKbps = -1F;
+                }
+
+                updateMaxBitRateEstimate(incomingBitrateKbps);
+            }
+            // Stay on hold until the pipes are cleared.
+            changeState(RateControlState.kRcHold, nowMs);
+            timeLastBitrateChange = nowMs;
+            break;
+        }
+
+        default:
+            throw new IllegalStateException("rateControlState");
+        }
+        if ((incomingBitrateBps > 100000L || currentBitrateBps > 150000L)
+                && currentBitrateBps > 1.5 * incomingBitrateBps)
+        {
+            // Allow changing the bit rate if we are operating at very low rates
+            // Don't change the bit rate if the send side is too far off
+            currentBitrateBps = this.currentBitrateBps;
+            timeLastBitrateChange = nowMs;
+        }
+        return currentBitrateBps;
+    }
+
+    private void changeRegion(RateControlRegion region, long nowMs)
+    {
+        if (rateControlRegion == region)
+        {
+            return;
+        }
+
+        rateControlRegion = region;
+
+        if (logger.isTraceEnabled())
+        {
+            logger.trace(diagnosticContext
+                    .makeTimeSeriesPoint("aimd_region", nowMs)
+                    .addField("aimd_id", hashCode())
+                    .addField("region", region));
+        }
+    }
+
+    private void changeState(RateControlInput input, long nowMs)
+    {
+        switch (currentInput.bwState)
+        {
+        case kBwNormal:
+            if (rateControlState == RateControlState.kRcHold)
+            {
+                timeLastBitrateChange = nowMs;
+                changeState(RateControlState.kRcIncrease, nowMs);
+            }
+            break;
+        case kBwOverusing:
+            if (rateControlState != RateControlState.kRcDecrease)
+            {
+                changeState(RateControlState.kRcDecrease, nowMs);
+            }
+            break;
+        case kBwUnderusing:
+            changeState(RateControlState.kRcHold, nowMs);
+            break;
+        default:
+            throw new IllegalStateException("currentInput.bwState");
+        }
+    }
+
+    private void changeState(RateControlState newState, long nowMs)
+    {
+        if (rateControlState == newState)
+        {
+            return;
+        }
+
+        rateControlState = newState;
+
+        if (logger.isTraceEnabled())
+        {
+            logger.trace(diagnosticContext
+                    .makeTimeSeriesPoint("aimd_state", nowMs)
+                    .addField("aimd_id", hashCode())
+                    .addField("state", rateControlState));
+        }
+    }
+
+    public long getFeedBackInterval()
+    {
+        // Estimate how often we can send RTCP if we allocate up to 5% of
+        // bandwidth to feedback.
+        long interval
+            = (long)
+                (kRtcpSize * 8.0 * 1000.0 / (0.05 * currentBitrateBps) + 0.5);
+
+        return
+            Math.min(
+                    Math.max(interval, kMinFeedbackIntervalMs),
+                    kMaxFeedbackIntervalMs);
+    }
+
+    public long getLatestEstimate()
+    {
+        return currentBitrateBps;
+    }
+
+    /**
+     * Returns <tt>true</tt> if the bitrate estimate hasn't been changed for
+     * more than an RTT, or if the <tt>incomingBitrate</tt> is more than 5%
+     * above the current estimate. Should be used to decide if we should reduce
+     * the rate further when over-using.
+     *
+     * @param timeNow
+     * @param incomingBitrateBps
+     * @return
+     */
+    public boolean isTimeToReduceFurther(long timeNow, long incomingBitrateBps)
+    {
+        long bitrateReductionInterval = Math.max(Math.min(rtt, 200L), 10L);
+
+        if (timeNow - timeLastBitrateChange >= bitrateReductionInterval)
+            return true;
+        if (isValidEstimate())
+        {
+          long threshold
+              = (long) (kWithinIncomingBitrateHysteresis * incomingBitrateBps);
+          long bitrateDifference = getLatestEstimate() - incomingBitrateBps;
+
+          return bitrateDifference > threshold;
+        }
+        return false;
+    }
+
+    /**
+     * Returns <tt>true</tt> if there is a valid estimate of the incoming
+     * bitrate, <tt>false</tt> otherwise.
+     *
+     * @return
+     */
+    public boolean isValidEstimate()
+    {
+        return bitrateIsInitialized;
+    }
+
+    private long multiplicativeRateIncrease(
+            long nowMs,
+            long lastMs,
+            long currentBitrateBps)
+    {
+        double alpha = 1.08;
+
+        if (lastMs > -1) {
+            long timeSinceLastUpdateMs = Math.min(nowMs - lastMs, 1000);
+
+            alpha = Math.pow(alpha,  timeSinceLastUpdateMs / 1000.0);
+        }
+        return (long) Math.max(currentBitrateBps * (alpha - 1.0), 1000.0);
+    }
+
+    public void reset()
+    {
+        reset(RemoteBitrateEstimator.kDefaultMinBitrateBps);
+    }
+
+    private void reset(long minBitrateBps)
+    {
+        minConfiguredBitrateBps = minBitrateBps;
+        currentBitrateBps = /* maxConfiguredBitrateBps */ 30000000L;
+        avgMaxBitrateKbps = -1F;
+        varMaxBitrateKbps = 0.4F;
+        rateControlState = RateControlState.kRcHold;
+        rateControlRegion = RateControlRegion.kRcMaxUnknown;
+        timeLastBitrateChange = -1L;
+        currentInput.bwState = BandwidthUsage.kBwNormal;
+        currentInput.incomingBitRate = 0L;
+        currentInput.noiseVar = 1D;
+        updated = false;
+        timeFirstIncomingEstimate = -1L;
+        bitrateIsInitialized = false;
+        beta = 0.85F;
+        rtt = kDefaultRttMs;
+        timeOfLastLog = -1L;
+        inExperiment = false;
+    }
+
+    public void setEstimate(long bitrateBps, long nowMs)
+    {
+        updated = true;
+        bitrateIsInitialized = true;
+        currentBitrateBps = changeBitrate(bitrateBps, bitrateBps, nowMs);
+    }
+
+    public void setMinBitrate(long minBitrateBps)
+    {
+        minConfiguredBitrateBps = minBitrateBps;
+        currentBitrateBps = Math.max(minBitrateBps, currentBitrateBps);
+    }
+
+    public void setRtt(long rtt)
+    {
+        if (logger.isTraceEnabled())
+        {
+            logger.trace(diagnosticContext
+                    .makeTimeSeriesPoint("aimd_rtt", System.currentTimeMillis())
+                    .addField("aimd_id", hashCode())
+                    .addField("rtt", rtt));
+        }
+
+        this.rtt = rtt;
+    }
+
+    public void update(RateControlInput input, long nowMs)
+    {
+        if (input == null)
+            throw new NullPointerException("input");
+
+        // Set the initial bit rate value to what we're receiving the first half
+        // second.
+        if (!bitrateIsInitialized)
+        {
+            if (timeFirstIncomingEstimate < 0L)
+            {
+                if (input.incomingBitRate > 0L)
+                    timeFirstIncomingEstimate = nowMs;
+            }
+            else if (nowMs - timeFirstIncomingEstimate > kInitializationTimeMs
+                    && input.incomingBitRate > 0L)
+            {
+                currentBitrateBps = input.incomingBitRate;
+                bitrateIsInitialized = true;
+            }
+        }
+
+        if (updated && currentInput.bwState == BandwidthUsage.kBwOverusing)
+        {
+            // Only update delay factor and incoming bit rate. We always want to
+            // react on an over-use.
+            currentInput.noiseVar = input.noiseVar;
+            currentInput.incomingBitRate = input.incomingBitRate;
+        }
+        else
+        {
+            updated = true;
+            currentInput.copy(input);
+        }
+    }
+
+    public long updateBandwidthEstimate(long nowMs)
+    {
+        currentBitrateBps
+            = changeBitrate(
+                    currentBitrateBps,
+                    currentInput.incomingBitRate,
+                    nowMs);
+
+        if (logger.isTraceEnabled() && isValidEstimate())
+        {
+            logger.trace(diagnosticContext
+                .makeTimeSeriesPoint("aimd_estimate", nowMs)
+                .addField("aimd_id", hashCode())
+                .addField("estimate_bps", currentBitrateBps)
+                .addField("incoming_bps", currentInput.incomingBitRate));
+        }
+
+        if (nowMs - timeOfLastLog > kLogIntervalMs)
+            timeOfLastLog = nowMs;
+        return currentBitrateBps;
+    }
+
+    private void updateMaxBitRateEstimate(float incomingBitrateKbps)
+    {
+        float alpha = 0.05F;
+
+        if (avgMaxBitrateKbps == -1F)
+        {
+            avgMaxBitrateKbps = incomingBitrateKbps;
+        }
+        else
+        {
+            avgMaxBitrateKbps
+                = (1 - alpha) * avgMaxBitrateKbps + alpha * incomingBitrateKbps;
+        }
+
+        // Estimate the max bit rate variance and normalize the variance with
+        // the average max bit rate.
+        float norm = Math.max(avgMaxBitrateKbps, 1F);
+
+        varMaxBitrateKbps
+            = (1 - alpha) * varMaxBitrateKbps
+                + alpha
+                    * (avgMaxBitrateKbps - incomingBitrateKbps)
+                    * (avgMaxBitrateKbps - incomingBitrateKbps)
+                    / norm;
+        // 0.4 ~= 14 kbit/s at 500 kbit/s
+        if (varMaxBitrateKbps < 0.4F)
+            varMaxBitrateKbps = 0.4F;
+        // 2.5f ~= 35 kbit/s at 500 kbit/s
+        if (varMaxBitrateKbps > 2.5f)
+            varMaxBitrateKbps = 2.5f;
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
-import org.jitsi.service.neomedia.rtp.*;
+import org.jitsi_modified.service.neomedia.rtp.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging.*;
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -17,7 +17,8 @@ package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi_modified.service.neomedia.rtp.*;
 import org.jetbrains.annotations.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging.TimeSeriesLogger;
 
 /**
  * A rate control implementation based on additive increases of bitrate when no

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/BandwidthUsage.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/BandwidthUsage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h
+ *
+ * @author Lyubomir Marinov
+ */
+enum BandwidthUsage
+{
+    kBwNormal(0), kBwUnderusing(-1), kBwOverusing(1);
+
+    private int value;
+    BandwidthUsage(int value){
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/BandwidthUsage.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/BandwidthUsage.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+import org.jitsi.utils.TimestampUtils;
+import org.jetbrains.annotations.*;
+import org.jitsi.utils.logging.*;
+
+/**
+ * Helper class to compute the inter-arrival time delta and the size delta
+ * between two timestamp groups. A timestamp is a 32 bit unsigned number with a
+ * client defined rate.
+ *
+ * webrtc/modules/remote_bitrate_estimator/inter_arrival.cc
+ * webrtc/modules/remote_bitrate_estimator/inter_arrival.h
+ *
+ * @author Lyubomir Marinov
+ * @author Julian Chukwu
+ * @author George Politis
+ */
+class InterArrival
+{
+    private static final int kBurstDeltaThresholdMs  = 5;
+
+    private static final Logger logger = Logger.getLogger(InterArrival.class);
+
+    /**
+     * webrtc/modules/include/module_common_types.h
+     *
+     * @param timestamp1
+     * @param timestamp2
+     * @return
+     */
+    private static long latestTimestamp(long timestamp1, long timestamp2)
+    {
+        return TimestampUtils.latestTimestamp(timestamp1, timestamp2);
+    }
+
+    private boolean burstGrouping;
+
+    private TimestampGroup currentTimestampGroup = new TimestampGroup();
+
+    private final long kTimestampGroupLengthTicks;
+
+    private final DiagnosticContext diagnosticContext;
+
+    private TimestampGroup prevTimestampGroup = new TimestampGroup();
+
+    private double timestampToMsCoeff;
+
+    private int numConsecutiveReorderedPackets;
+
+    // After this many packet groups received out of order InterArrival will
+    // reset, assuming that clocks have made a jump.
+    private static final int kReorderedResetThreshold = 3;
+    private static final int kArrivalTimeOffsetThresholdMs = 3000;
+
+    /**
+     * A timestamp group is defined as all packets with a timestamp which are at
+     * most {@code timestampGroupLengthTicks} older than the first timestamp in
+     * that group.
+     *
+     * @param timestampGroupLengthTicks
+     * @param timestampToMsCoeff
+     * @param enableBurstGrouping
+     */
+    public InterArrival(
+            long timestampGroupLengthTicks,
+            double timestampToMsCoeff,
+            boolean enableBurstGrouping,
+            @NotNull DiagnosticContext diagnosticContext)
+    {
+        kTimestampGroupLengthTicks = timestampGroupLengthTicks;
+        this.timestampToMsCoeff = timestampToMsCoeff;
+        burstGrouping = enableBurstGrouping;
+        numConsecutiveReorderedPackets = 0;
+        this.diagnosticContext = diagnosticContext;
+    }
+
+    private boolean belongsToBurst(long arrivalTimeMs, long timestamp)
+    {
+        if (!burstGrouping)
+            return false;
+
+        if (currentTimestampGroup.completeTimeMs < 0)
+        {
+            throw new IllegalStateException(
+                    "currentTimestampGroup.completeTimeMs");
+        }
+
+        long arrivalTimeDeltaMs
+            = arrivalTimeMs - currentTimestampGroup.completeTimeMs;
+
+        long timestampDiff = TimestampUtils
+            .subtractAsUnsignedInt32(timestamp, currentTimestampGroup.timestamp);
+
+        long tsDeltaMs = (long) (timestampToMsCoeff * timestampDiff + 0.5);
+
+        if (tsDeltaMs == 0)
+            return true;
+
+        long propagationDeltaMs = arrivalTimeDeltaMs - tsDeltaMs;
+
+        return
+            propagationDeltaMs < 0
+                && arrivalTimeDeltaMs <= kBurstDeltaThresholdMs;
+    }
+
+    /**
+     * Returns {@code true} if a delta was computed, or {@code false} if the
+     * current group is still incomplete or if only one group has been
+     * completed.
+     *
+     * @param timestamp is the timestamp.
+     * @param arrivalTimeMs is the local time at which the packet arrived.
+     * @param packetSize is the size of the packet.
+     * @param deltas {@code timestampDelta} is the computed timestamp delta,
+     * {@code arrivalTimeDeltaMs} is the computed arrival-time delta,
+     * {@code packetSizeDelta} is the computed size delta.
+     * @return
+     *
+     * @Note: We have two {@code computeDeltas}.
+     * One with a valid {@code systemTimeMs} according to webrtc
+     * implementation as of June 12,2017 and a previous one
+     * with a default systemTimeMs (-1L). the later may be removed or
+     * deprecated.
+     */
+    public boolean computeDeltas(
+            long timestamp,
+            long arrivalTimeMs,
+            int packetSize,
+            long[] deltas){
+
+                return computeDeltas(timestamp,arrivalTimeMs,
+                        packetSize,deltas,-1L);
+    }
+
+    public boolean computeDeltas(
+            long timestamp,
+            long arrivalTimeMs,
+            int packetSize,
+            long[] deltas,
+            long systemTimeMs)
+    {
+        if (deltas == null)
+            throw new NullPointerException("deltas");
+        if (deltas.length != 3)
+            throw new IllegalArgumentException("deltas.length");
+
+        boolean calculatedDeltas = false;
+
+        if (currentTimestampGroup.isFirstPacket())
+        {
+            // We don't have enough data to update the filter, so we store it
+            // until we have two frames of data to process.
+            currentTimestampGroup.timestamp = timestamp;
+            currentTimestampGroup.firstTimestamp = timestamp;
+        }
+        else if (!isPacketInOrder(timestamp))
+        {
+            return false;
+        }
+        else if (isNewTimestampGroup(arrivalTimeMs, timestamp))
+        {
+            // First packet of a later frame, the previous frame sample is
+            // ready.
+            if (prevTimestampGroup.completeTimeMs >= 0)
+            {
+                /* long timestampDelta */ deltas[0]
+                    = TimestampUtils.subtractAsUnsignedInt32(
+                        currentTimestampGroup.timestamp,
+                        prevTimestampGroup.timestamp);
+
+                long arrivalTimeDeltaMs
+                    = deltas[1]
+                    = currentTimestampGroup.completeTimeMs
+                        - prevTimestampGroup.completeTimeMs;
+
+                // Check system time differences to see if we have an unproportional jump
+                // in arrival time. In that case reset the inter-arrival computations.
+                long systemTimeDeltaMs =
+                        currentTimestampGroup.lastSystemTimeMs -
+                                prevTimestampGroup.lastSystemTimeMs;
+                if (prevTimestampGroup.lastSystemTimeMs != -1L &&
+                        currentTimestampGroup.lastSystemTimeMs != -1L &&
+                        arrivalTimeDeltaMs - systemTimeDeltaMs >=
+                    kArrivalTimeOffsetThresholdMs) {
+                    logger.warn( "The arrival time clock offset has changed (diff = "
+                            + String.valueOf(arrivalTimeDeltaMs - systemTimeDeltaMs)
+                            +  " ms), resetting.");
+                    Reset();
+                    return false;
+                }
+
+                if (arrivalTimeDeltaMs < 0)
+                {
+                    ++numConsecutiveReorderedPackets;
+                    if (numConsecutiveReorderedPackets >= kReorderedResetThreshold) {
+                        // The group of packets has been reordered since receiving
+                        // its local arrival timestamp.
+                        logger.warn(
+                                "Packets are being reordered on the path from the "
+                                    + "socket to the bandwidth estimator. Ignoring "
+                                    + "this packet for bandwidth estimation.");
+                        Reset();
+                    }
+                    return false;
+                }
+                else
+                {
+                    numConsecutiveReorderedPackets = 0;
+                }
+                /* int packetSizeDelta */ deltas[2]
+                    = (int)
+                        (currentTimestampGroup.size - prevTimestampGroup.size);
+
+                if (logger.isTraceEnabled())
+                {
+                    logger.trace(diagnosticContext
+                        .makeTimeSeriesPoint("computed_deltas")
+                        .addField("inter_arrival", hashCode())
+                        .addField("arrival_time_ms", arrivalTimeMs)
+                        .addField("timestamp_delta", deltas[0])
+                        .addField("arrival_time_ms_delta", deltas[1])
+                        .addField("payload_size_delta", deltas[2]));
+                }
+
+                calculatedDeltas = true;
+            }
+            prevTimestampGroup.copy(currentTimestampGroup);
+            // The new timestamp is now the current frame.
+            currentTimestampGroup.firstTimestamp = timestamp;
+            currentTimestampGroup.timestamp = timestamp;
+            currentTimestampGroup.size = 0;
+
+        }
+        else
+        {
+            currentTimestampGroup.timestamp = latestTimestamp(
+                    currentTimestampGroup.timestamp, timestamp);
+        }
+        // Accumulate the frame size.
+        currentTimestampGroup.size += packetSize;
+        currentTimestampGroup.completeTimeMs = arrivalTimeMs;
+        currentTimestampGroup.lastSystemTimeMs = systemTimeMs;
+
+        return calculatedDeltas;
+    }
+
+    /**
+     * Returns {@code true} if the last packet was the end of the current batch
+     * and the packet with {@code timestamp} is the first of a new batch.
+     *
+     * @param arrivalTimeMs
+     * @param timestamp
+     * @return
+     */
+    private boolean isNewTimestampGroup(long arrivalTimeMs, long timestamp)
+    {
+        if (currentTimestampGroup.isFirstPacket())
+        {
+            return false;
+        }
+        else if (belongsToBurst(arrivalTimeMs, timestamp))
+        {
+            return false;
+        }
+        else
+        {
+            long timestampDiff
+                = TimestampUtils.subtractAsUnsignedInt32(
+                    timestamp, currentTimestampGroup.firstTimestamp);
+
+            return timestampDiff > kTimestampGroupLengthTicks;
+        }
+    }
+
+    /**
+     * Returns {@code true} if the packet with timestamp {@code timestamp}
+     * arrived in order.
+     *
+     * @param timestamp
+     * @return
+     */
+    private boolean isPacketInOrder(long timestamp)
+    {
+        if (currentTimestampGroup.isFirstPacket())
+        {
+            return true;
+        }
+        else
+        {
+            // Assume that a diff which is bigger than half the timestamp
+            // interval (32 bits) must be due to reordering. This code is almost
+            // identical to that in isNewerTimestamp() in module_common_types.h.
+            long timestampDiff
+                = TimestampUtils.subtractAsUnsignedInt32(
+                    timestamp, currentTimestampGroup.firstTimestamp);
+
+            long tsDeltaMs = (long) (timestampToMsCoeff * timestampDiff + 0.5);
+            boolean inOrder = timestampDiff < 0x80000000L;
+
+            if (!inOrder && logger.isTraceEnabled())
+            {
+                logger.trace(diagnosticContext
+                        .makeTimeSeriesPoint("reordered_packet")
+                        .addField("inter_arrival", hashCode())
+                        .addField("ts_delta_ms", tsDeltaMs));
+            }
+
+            return inOrder;
+        }
+    }
+
+    private static class TimestampGroup
+    {
+        public long completeTimeMs = -1L;
+
+        public long size = 0L;
+
+        public long firstTimestamp = 0L;
+
+        public long timestamp = 0L;
+
+        public long lastSystemTimeMs = -1L;
+
+        /**
+         * Assigns the values of the fields of <tt>source</tt> to the respective
+         * fields of this {@code TimestampGroup}.
+         *
+         * @param source the {@code TimestampGroup} the values of the fields of
+         * which are to be assigned to the respective fields of this
+         * {@code TimestampGroup}
+         */
+        public void copy(TimestampGroup source)
+        {
+            completeTimeMs = source.completeTimeMs;
+            firstTimestamp = source.firstTimestamp;
+            size = source.size;
+            timestamp = source.timestamp;
+        }
+
+        public boolean isFirstPacket()
+        {
+            return completeTimeMs == -1L;
+        }
+    }
+
+    public void Reset() {
+        numConsecutiveReorderedPackets = 0;
+        currentTimestampGroup = new TimestampGroup();
+        prevTimestampGroup = new TimestampGroup();
+
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -17,7 +17,8 @@ package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.utils.TimestampUtils;
 import org.jetbrains.annotations.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging2.*;
 
 /**
  * Helper class to compute the inter-arrival time delta and the size delta
@@ -35,7 +36,7 @@ class InterArrival
 {
     private static final int kBurstDeltaThresholdMs  = 5;
 
-    private static final Logger logger = Logger.getLogger(InterArrival.class);
+    private final Logger logger;
 
     /**
      * webrtc/modules/include/module_common_types.h
@@ -81,13 +82,15 @@ class InterArrival
             long timestampGroupLengthTicks,
             double timestampToMsCoeff,
             boolean enableBurstGrouping,
-            @NotNull DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext,
+            @NotNull Logger parentLogger)
     {
         kTimestampGroupLengthTicks = timestampGroupLengthTicks;
         this.timestampToMsCoeff = timestampToMsCoeff;
         burstGrouping = enableBurstGrouping;
         numConsecutiveReorderedPackets = 0;
         this.diagnosticContext = diagnosticContext;
+        this.logger = parentLogger.createChildLogger(getClass().getName());
     }
 
     private boolean belongsToBurst(long arrivalTimeMs, long timestamp)

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.utils.TimestampUtils;
 import org.jetbrains.annotations.*;

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OverUseDetectorOptions.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OverUseDetectorOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+/**
+ * Bandwidth over-use detector options.  These are used to drive experimentation
+ * with bandwidth estimation parameters.
+ *
+ * webrtc/common_types.h
+ *
+ * @author Lyubomir Marinov
+ */
+class OverUseDetectorOptions
+{
+    public double initialAvgNoise = 0.0D;
+
+    public final double[][] initialE
+        = new double[][] { { 100, 0 }, { 0, 1e-1 } };
+
+    public double initialOffset = 0.0D;
+
+    public final double[] initialProcessNoise = new double[] { 1e-10, 1e-2 };
+
+    public double initialSlope = 8.0D / 512.0D;
+
+    public double initialThreshold = 25.0D;
+
+    public double initialVarNoise = 50.0D;
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OverUseDetectorOptions.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OverUseDetectorOptions.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 /**
  * Bandwidth over-use detector options.  These are used to drive experimentation

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+import org.jetbrains.annotations.*;
+import org.jitsi.utils.logging.*;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/overuse_detector.cc
+ * webrtc/modules/remote_bitrate_estimator/overuse_detector.h
+ *
+ * @author Lyubomir Marinov
+ */
+class OveruseDetector
+{
+    private static final Logger logger
+        = Logger.getLogger(OveruseDetector.class);
+
+    private static final double kMaxAdaptOffsetMs = 15.0;
+
+    private static final int kOverUsingTimeThreshold = 100;
+
+    private BandwidthUsage hypothesis = BandwidthUsage.kBwNormal;
+
+    private final boolean inExperiment = false; // AdaptiveThresholdExperimentIsEnabled()
+
+    private double kDown = 0.00018D;
+
+    private double kUp = 0.01D;
+
+    private long lastUpdateMs = -1L;
+
+    private int overuseCounter;
+
+    private double overusingTimeThreshold = 100D;
+
+    private double prevOffset;
+
+    private double threshold = 12.5D;
+
+    private double timeOverUsing = -1D;
+
+    private final DiagnosticContext diagnosticContext;
+
+    public OveruseDetector(
+            OverUseDetectorOptions options,
+            @NotNull DiagnosticContext diagnosticContext)
+    {
+        if (options == null)
+            throw new NullPointerException("options");
+
+        threshold = options.initialThreshold;
+        this.diagnosticContext = diagnosticContext;
+
+        if (inExperiment)
+            initializeExperiment();
+    }
+
+    /**
+     * Update the detection state based on the estimated inter-arrival time
+     * delta offset. {@code timestampDelta} is the delta between the last
+     * timestamp which the estimated offset is based on and the last timestamp
+     * on which the last offset was based on, representing the time between
+     * detector updates. {@code numOfDeltas} is the number of deltas the offset
+     * estimate is based on. Returns the state after the detection update.
+     *
+     * @param offset
+     * @param tsDelta
+     * @param numOfDeltas
+     * @param nowMs
+     * @return
+     */
+    public BandwidthUsage detect(
+            double offset,
+            double tsDelta,
+            int numOfDeltas,
+            long nowMs)
+    {
+        if (numOfDeltas < 2)
+            return BandwidthUsage.kBwNormal;
+
+        double prev_offset = this.prevOffset;
+
+        this.prevOffset = offset;
+
+        double T = Math.min(numOfDeltas, 60) * offset;
+
+        boolean newHypothesis = false;
+
+        if (T > threshold)
+        {
+            if (timeOverUsing == -1)
+            {
+                // Initialize the timer. Assume that we've been
+                // over-using half of the time since the previous
+                // sample.
+                timeOverUsing = tsDelta / 2;
+            }
+            else
+            {
+                // Increment timer
+                timeOverUsing += tsDelta;
+            }
+            overuseCounter++;
+            if (timeOverUsing > overusingTimeThreshold && overuseCounter > 1)
+            {
+                if (offset >= prev_offset)
+                {
+                    timeOverUsing = 0;
+                    overuseCounter = 0;
+                    hypothesis = BandwidthUsage.kBwOverusing;
+                    newHypothesis = true;
+                }
+            }
+        }
+        else if (T < -threshold)
+        {
+            timeOverUsing = -1;
+            overuseCounter = 0;
+            hypothesis = BandwidthUsage.kBwUnderusing;
+            newHypothesis = true;
+        }
+        else
+        {
+            timeOverUsing = -1;
+            overuseCounter = 0;
+            hypothesis = BandwidthUsage.kBwNormal;
+            newHypothesis = true;
+        }
+
+        if (newHypothesis && logger.isTraceEnabled())
+        {
+            logger.trace(diagnosticContext
+                .makeTimeSeriesPoint("utilization_hypothesis", nowMs)
+                .addField("detector", hashCode())
+                .addField("offset", offset)
+                .addField("prev_offset", prev_offset)
+                .addField("T", T)
+                .addField("threshold", threshold)
+                .addField("hypothesis", hypothesis.getValue()));
+        }
+
+        updateThreshold(T, nowMs);
+
+        return hypothesis;
+    }
+
+    /**
+     * Returns the current detector state.
+     *
+     * @return
+     */
+    public BandwidthUsage getState()
+    {
+        return hypothesis;
+    }
+
+    private void initializeExperiment()
+    {
+        double kUp = 0.0;
+        double kDown = 0.0;
+
+        overusingTimeThreshold = kOverUsingTimeThreshold;
+//        if (readExperimentConstants(kUp, kDown))
+        {
+            this.kUp = kUp;
+            this.kDown = kDown;
+        }
+    }
+
+    private void updateThreshold(double modifiedOffset, long nowMs)
+    {
+        if (!inExperiment)
+            return;
+
+        if (lastUpdateMs == -1)
+            lastUpdateMs = nowMs;
+
+        if (Math.abs(modifiedOffset) > threshold + kMaxAdaptOffsetMs)
+        {
+            // Avoid adapting the threshold to big latency spikes, caused e.g.,
+            // by a sudden capacity drop.
+            lastUpdateMs = nowMs;
+            return;
+        }
+
+        double k = Math.abs(modifiedOffset) < threshold ? kDown : kUp;
+
+        threshold
+            += k
+                * (Math.abs(modifiedOffset) - threshold)
+                * (nowMs - lastUpdateMs);
+
+        final double kMinThreshold = 6;
+        final double kMaxThreshold = 600;
+
+        threshold = Math.min(Math.max(threshold, kMinThreshold), kMaxThreshold);
+
+        lastUpdateMs = nowMs;
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -16,7 +16,8 @@
 package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jetbrains.annotations.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging2.*;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/overuse_detector.cc
@@ -26,8 +27,7 @@ import org.jitsi.utils.logging.*;
  */
 class OveruseDetector
 {
-    private static final Logger logger
-        = Logger.getLogger(OveruseDetector.class);
+    private final Logger logger;
 
     private static final double kMaxAdaptOffsetMs = 15.0;
 
@@ -57,12 +57,14 @@ class OveruseDetector
 
     public OveruseDetector(
             OverUseDetectorOptions options,
-            @NotNull DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext,
+            @NotNull Logger parentLogger)
     {
         if (options == null)
             throw new NullPointerException("options");
 
         threshold = options.initialThreshold;
+        logger = parentLogger.createChildLogger(getClass().getName());
         this.diagnosticContext = diagnosticContext;
 
         if (inExperiment)

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging.*;

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+import org.jetbrains.annotations.*;
+import org.jitsi.utils.logging.*;
+
+import java.util.*;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/overuse_estimator.cc
+ * webrtc/modules/remote_bitrate_estimator/overuse_estimator.h
+ *
+ * @author Lyubomir Marinov
+ */
+class OveruseEstimator
+{
+    /**
+     * The <tt>Logger</tt> used by the
+     * <tt>RemoteBitrateEstimatorAbsSendTime</tt> class and its instances for
+     * logging output.
+     */
+    private static final Logger logger
+        = Logger.getLogger(OveruseEstimator.class);
+
+    private static final int kDeltaCounterMax = 1000;
+
+    private static final int kMinFramePeriodHistoryLength = 60;
+
+    /**
+     * Creates and returns a deep copy of a <tt>double</tt> two-dimensional
+     * matrix.
+     *
+     * @param matrix the <tt>double</tt> two-dimensional matrix to create and
+     * return a deep copy of
+     * @return a deep copy of <tt>matrix</tt>
+     */
+    private static double[][] clone(double[][] matrix)
+    {
+        int length = matrix.length;
+        double[][] clone;
+
+        clone = new double[length][];
+        for (int i = 0; i < length; i++)
+            clone[i] = matrix[i].clone();
+        return clone;
+    }
+
+    private double avgNoise;
+
+    private final double[][] E;
+
+    private DiagnosticContext diagnosticContext;
+
+    /**
+     * Reduces the effects of allocations and garbage collection of the method
+     * {@code update}.
+     */
+    private final double[] Eh = new double[2];
+
+    /**
+     * Reduces the effects of allocations and garbage collection of the method
+     * {@code update}.
+     */
+    private final double[] h = new double[2];
+
+    /**
+     * Reduces the effects of allocations and garbage collection of the method
+     * {@code update}.
+     */
+    private final double[][] IKh = new double[][] { { 0, 0 }, { 0, 0 } };
+
+    /**
+     * Reduces the effects of allocations and garbage collection of the method
+     * {@code update}.
+     */
+    private final double[] K = new double[2];
+
+    private int numOfDeltas;
+
+    private double offset;
+
+    private double prevOffset;
+
+    private final double[] processNoise;
+
+    private double slope;
+
+    /**
+     * Store the tsDelta history into a {@code double[]} used as a circular buffer
+     * Original c++ code uses std::list<double> but in Java this translate
+     * to {@code List<Double>} which causes a lot of autoboxing
+     */
+    private final double[] tsDeltaHist = new double[kMinFramePeriodHistoryLength];
+
+    /**
+     * Index to insert next value into {@link #tsDeltaHist}
+     */
+    private int tsDeltaHistInsIdx;
+
+    private double varNoise;
+
+    public OveruseEstimator(
+            OverUseDetectorOptions options,
+            @NotNull DiagnosticContext diagnosticContext)
+    {
+        this.diagnosticContext = diagnosticContext;
+        slope = options.initialSlope;
+        offset = options.initialOffset;
+        prevOffset = offset;
+        avgNoise = options.initialAvgNoise;
+        varNoise = options.initialVarNoise;
+        E = clone(options.initialE);
+        processNoise = options.initialProcessNoise.clone();
+        /**
+         * Initialize {@link tsDeltaHist} with {@code Double.MAX_VALUE}
+         * to simplify {@link updateMinFramePeriod}
+         */
+        Arrays.fill(tsDeltaHist, Double.MAX_VALUE);
+    }
+
+    /**
+     * Returns the number of deltas which the current over-use estimator state
+     * is based on.
+     *
+     * @return
+     */
+    public int getNumOfDeltas()
+    {
+        return numOfDeltas;
+    }
+
+    /**
+     * Returns the estimated inter-arrival time delta offset in ms.
+     *
+     * @return
+     */
+    public double getOffset()
+    {
+        return offset;
+    }
+
+    /**
+     * Returns the estimated noise/jitter variance in ms^2.
+     *
+     * @return
+     */
+    public double getVarNoise()
+    {
+        return varNoise;
+    }
+
+    /**
+     * Update the estimator with a new sample. The deltas should represent
+     * deltas between timestamp groups as defined by the InterArrival class.
+     * {@code currentHypothesis} should be the hypothesis of the over-use
+     * detector at this time.
+     *
+     * @param tDelta
+     * @param tsDelta
+     * @param sizeDelta
+     * @param currentHypothesis
+     */
+    public void update(
+            long tDelta,
+            double tsDelta,
+            int sizeDelta,
+            BandwidthUsage currentHypothesis, long systemTimeMs)
+    {
+        double minFramePeriod = updateMinFramePeriod(tsDelta);
+        double tTsDelta = tDelta - tsDelta;
+
+        ++numOfDeltas;
+        if (numOfDeltas > kDeltaCounterMax)
+            numOfDeltas = kDeltaCounterMax;
+
+        // Update the Kalman filter
+        E[0][0] += processNoise[0];
+        E[1][1] += processNoise[1];
+
+        if ((currentHypothesis == BandwidthUsage.kBwOverusing
+                    && offset < prevOffset)
+                || (currentHypothesis == BandwidthUsage.kBwUnderusing
+                    && offset > prevOffset))
+        {
+            E[1][1] += 10D * processNoise[1];
+        }
+
+        double[] h = this.h;
+        double[] Eh = this.Eh;
+
+        h[0] = sizeDelta;
+        h[1] = 1D;
+        Eh[0] = E[0][0] * h[0] + E[0][1] * h[1];
+        Eh[1] = E[1][0] * h[0] + E[1][1] * h[1];
+
+        double residual = tTsDelta - slope * h[0] - offset;
+        boolean inStableState = (currentHypothesis == BandwidthUsage.kBwNormal);
+
+        // We try to filter out very late frames. For instance periodic key
+        // frames doesn't fit the Gaussian model well.
+        double maxResidual = 3D * Math.sqrt(varNoise);
+        double residualForUpdateNoiseEstimate
+            = (Math.abs(residual) < maxResidual)
+                ? residual
+                : (residual < 0 ? -maxResidual : maxResidual);
+
+        updateNoiseEstimate(
+                residualForUpdateNoiseEstimate,
+                minFramePeriod,
+                inStableState);
+
+        double denom = varNoise + h[0]*Eh[0] + h[1]*Eh[1];
+        double[] K = this.K;
+        double[][] IKh = this.IKh;
+
+        K[0] = Eh[0] / denom;
+        K[1] = Eh[1] / denom;
+        IKh[0][0] = 1D - K[0]*h[0];
+        IKh[0][1] = -K[0]*h[1];
+        IKh[1][0] = -K[1]*h[0];
+        IKh[1][1] = 1D - K[1]*h[1];
+
+        double e00 = E[0][0];
+        double e01 = E[0][1];
+
+        // Update state.
+        E[0][0] = e00 * IKh[0][0] + E[1][0] * IKh[0][1];
+        E[0][1] = e01 * IKh[0][0] + E[1][1] * IKh[0][1];
+        E[1][0] = e00 * IKh[1][0] + E[1][0] * IKh[1][1];
+        E[1][1] = e01 * IKh[1][0] + E[1][1] * IKh[1][1];
+
+        // Covariance matrix, must be positive semi-definite.
+        boolean positiveSemiDefinite
+                = E[0][0] + E[1][1] >= 0
+                    && E[0][0] * E[1][1] - E[0][1] * E[1][0] >= 0
+                    && E[0][0] >= 0;
+
+        if (!positiveSemiDefinite)
+            throw new IllegalStateException("positiveSemiDefinite");
+
+        slope = slope + K[0] * residual;
+        prevOffset = offset;
+        offset = offset + K[1] * residual;
+
+        if (logger.isTraceEnabled())
+        {
+            logger.trace(diagnosticContext
+                .makeTimeSeriesPoint("delay_variation_estimation", systemTimeMs)
+                .addField("estimator", hashCode())
+                .addField("time_delta", tDelta)
+                .addField("ts_delta", tsDelta)
+                .addField("tts_delta", tTsDelta)
+                .addField("offset", offset)
+                .addField("hypothesis", currentHypothesis.getValue()));
+        }
+    }
+
+    private double updateMinFramePeriod(double tsDelta)
+    {
+        /**
+         * Change from C++ version:
+         * We use {@link tsDeltaHist} as a circular buffer initialized
+         * with {@code Double.MAX_VALUE}, so we insert new {@link tsDelta}
+         * value at {@link tsDeltaHistInsIdx} and we search for the
+         * minimum value in {@link tsDeltaHist}
+         */
+        tsDeltaHist[tsDeltaHistInsIdx] = tsDelta;
+        tsDeltaHistInsIdx = (tsDeltaHistInsIdx + 1) % tsDeltaHist.length;
+
+        double min = tsDelta;
+        for (double d : tsDeltaHist)
+        {
+            if (d < min)
+                min = d;
+        }
+
+        return min;
+    }
+
+    private void updateNoiseEstimate(
+            double residual,
+            double tsDelta,
+            boolean stableState)
+    {
+        if (!stableState)
+            return;
+
+        // Faster filter during startup to faster adapt to the jitter level of
+        // the network alpha is tuned for 30 frames per second, but is scaled
+        // according to tsDelta.
+        double alpha = 0.01D;
+
+        if (numOfDeltas > 10 * 30)
+            alpha = 0.002D;
+
+        // Only update the noise estimate if we're not over-using beta is a
+        // function of alpha and the time delta since the previous update.
+        double beta = Math.pow(1 - alpha, tsDelta * 30D / 1000D);
+
+        avgNoise = beta * avgNoise + (1 - beta) * residual;
+        varNoise
+            = beta * varNoise
+                + (1 - beta) * (avgNoise - residual) * (avgNoise - residual);
+        if (varNoise < 1)
+            varNoise = 1;
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging.*;

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -16,7 +16,8 @@
 package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jetbrains.annotations.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging2.*;
 
 import java.util.*;
 
@@ -29,12 +30,11 @@ import java.util.*;
 class OveruseEstimator
 {
     /**
-     * The <tt>Logger</tt> used by the
-     * <tt>RemoteBitrateEstimatorAbsSendTime</tt> class and its instances for
+     * The <tt>Logger</tt> used by
+     * <tt>OveruseEstimator</tt> instances for
      * logging output.
      */
-    private static final Logger logger
-        = Logger.getLogger(OveruseEstimator.class);
+    private final Logger logger;
 
     private static final int kDeltaCounterMax = 1000;
 
@@ -115,8 +115,10 @@ class OveruseEstimator
 
     public OveruseEstimator(
             OverUseDetectorOptions options,
-            @NotNull DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext,
+            @NotNull Logger parentLogger)
     {
+        logger = parentLogger.createChildLogger(getClass().getName());
         this.diagnosticContext = diagnosticContext;
         slope = options.initialSlope;
         offset = options.initialOffset;

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlInput.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlInput.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h
+ *
+ * @author Lyubomir Marinov
+ */
+class RateControlInput
+{
+    public BandwidthUsage bwState;
+
+    public long incomingBitRate;
+
+    public double noiseVar;
+
+    public RateControlInput(
+            BandwidthUsage bwState,
+            long incomingBitRate,
+            double noiseVar)
+    {
+        this.bwState = bwState;
+        this.incomingBitRate = incomingBitRate;
+        this.noiseVar = noiseVar;
+    }
+
+    /**
+     * Assigns the values of the fields of <tt>source</tt> to the respective
+     * fields of this <tt>RateControlInput</tt>.
+     *
+     * @param source the <tt>RateControlInput</tt> the values of the fields of
+     * which are to be assigned to the respective fields of this
+     * <tt>RateControlInput</tt>
+     */
+    public void copy(RateControlInput source)
+    {
+        bwState = source.bwState;
+        incomingBitRate = source.incomingBitRate;
+        noiseVar = source.noiseVar;
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlInput.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlInput.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlRegion.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlRegion.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h
+ *
+ * @author Lyubomir Marinov
+ */
+enum RateControlRegion
+{
+    kRcNearMax,
+    kRcAboveMax,
+    kRcMaxUnknown
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlRegion.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlRegion.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlState.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlState.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h
+ *
+ * @author Lyubomir Marinov
+ */
+enum RateControlState
+{
+    kRcHold,
+    kRcIncrease,
+    kRcDecrease
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlState.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RateControlState.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+
+import org.jitsi.service.neomedia.rtp.*;
+import org.jetbrains.annotations.*;
+import org.jitsi.utils.logging.*;
+import org.jitsi.utils.stats.*;
+
+import java.util.*;
+
+/**
+ * webrtc.org abs_send_time implementation as of June 26, 2017.
+ * commit ID: 23fbd2aa2c81d065b84d17b09b747e75672e1159
+ *
+ * @author Julian Chukwu
+ * @author George Politis
+ */
+public class RemoteBitrateEstimatorAbsSendTime
+    implements RemoteBitrateEstimator
+{
+    /**
+     * The {@link TimeSeriesLogger} to be used by this instance to print time
+     * series.
+     */
+    private static final TimeSeriesLogger timeSeriesLogger
+        = TimeSeriesLogger.getTimeSeriesLogger(
+                RemoteBitrateEstimatorAbsSendTime.class);
+
+    /**
+     * Defines the number of digits in the AST representation (24 bits, 6.18
+     * fixed point) after the radix.
+     */
+    private final static int kAbsSendTimeFraction = 18;
+
+    /**
+     * Defines the upshift (left bit-shift) to apply to AST (24 bits, 6.18 fixed
+     * point) to make it inter-arrival compatible (expanded AST, 32 bits, 6.26
+     * fixed point).
+     */
+    private final static int kAbsSendTimeInterArrivalUpshift = 8;
+
+    /**
+     * This is used in the {@link InterArrival} computations. In this estimator
+     * a timestamp group is defined as all packets with a timestamp which are at
+     * most 5ms older than the first timestamp in that group.
+     */
+    private final static int kTimestampGroupLengthMs = 5;
+
+    /**
+     * Defines the number of digits in the expanded AST representation (32 bits,
+     * 6.26 fixed point) after the radix.
+     */
+    private final static int kInterArrivalShift
+        = kAbsSendTimeFraction + kAbsSendTimeInterArrivalUpshift;
+
+    /**
+     * Converts the {@link #kTimestampGroupLengthMs} into "ticks" for use with
+     * the {@link InterArrival}.
+     */
+    private static final long kTimestampGroupLengthTicks
+        = (kTimestampGroupLengthMs << kInterArrivalShift) / 1000;
+
+    /**
+     * Defines the expanded AST (32 bits) to millis conversion rate. Units are
+     * ms per timestamp
+     */
+    private static final double
+        kTimestampToMs = (double) 1000 / (1 << kInterArrivalShift);
+
+    /**
+     * Reduces the effects of allocations and garbage collection of the method
+     * {@code incomingPacket}.
+     */
+    private final long[] deltas = new long[3];
+
+    /**
+     * Reduces the effects of allocations and garbage collection of the method
+     * {@link #incomingPacketInfo(long, long, int, long)}} by promoting the
+     * {@code RateControlInput} instance from a local variable to a field and
+     * reusing the same instance across method invocations. (Consequently, the
+     * default values used to initialize the field are of no importance because
+     * they will be overwritten before they are actually used.)
+     */
+    private final RateControlInput input
+        = new RateControlInput(BandwidthUsage.kBwNormal, 0L, 0D);
+
+    /**
+     * The set of synchronization source identifiers (SSRCs) currently being
+     * received. Represents an unmodifiable copy/snapshot of the current keys of
+     * {@link #ssrcsMap} suitable for public access and introduced for
+     * the purposes of reducing the number of allocations and the effects of
+     * garbage collection.
+     */
+    private Collection<Long> ssrcs
+        = Collections.unmodifiableList(Collections.EMPTY_LIST);
+
+    /**
+     * A map of SSRCs -> time first seen (in millis).
+     */
+    private final Map<Long, Long> ssrcsMap = new TreeMap<>();
+
+    /**
+     * The time (in millis) when we saw the first packet. Useful to determine
+     * the probing period.
+     */
+    private long firstPacketTimeMs;
+
+    /**
+     * Keeps track of the last time (in millis) that we updated the bitrate
+     * estimate.
+     */
+    private long lastUpdateMs;
+
+    /**
+     * The observer to notify on bitrate estimation changes.
+     */
+    private final RemoteBitrateObserver observer;
+
+    /**
+     * The rate control implementation based on additive increases of bitrate
+     * when no over-use is detected and multiplicative decreases when over-uses
+     * are detected.
+     */
+    private final AimdRateControl remoteRate;
+
+    /**
+     * Holds the {@link InterArrival}, {@link OveruseEstimator} and
+     * {@link OveruseDetector} instances of this RBE.
+     */
+    private Detector detector;
+
+    /**
+     * Keeps track of how much data we're receiving.
+     */
+    private RateStatistics incomingBitrate;
+
+    /**
+     * Determines whether or not the incoming bitrate is initialized or not.
+     */
+    private boolean incomingBitrateInitialized;
+
+    /**
+     * The {@link DiagnosticContext} of this instance.
+     */
+    private final DiagnosticContext diagnosticContext;
+
+    /**
+     * Ctor.
+     *
+     * @param observer the observer to notify on bitrate estimation changes.
+     * @param diagnosticContext the {@link DiagnosticContext} of this instance.
+     */
+    public RemoteBitrateEstimatorAbsSendTime(
+            RemoteBitrateObserver observer,
+            @NotNull DiagnosticContext diagnosticContext)
+    {
+        this.observer = observer;
+        this.diagnosticContext = diagnosticContext;
+        this.remoteRate = new AimdRateControl(diagnosticContext);
+        this.incomingBitrate = new RateStatistics(kBitrateWindowMs, kBitrateScale);
+        this.incomingBitrateInitialized = false;
+        this.firstPacketTimeMs = -1;
+        this.lastUpdateMs = -1;
+    }
+
+    /**
+     * Notifies this instance of an incoming packet.
+     *
+     * @param arrivalTimeMs the arrival time of the packet in millis.
+     * @param sendTime24bits the send time of the packet in AST format
+     * (24 bits, 6.18 fixed point).
+     * @param payloadSize the payload size of the packet.
+     * @param ssrc the SSRC of the packet.
+     */
+    @Override
+    public void incomingPacketInfo(
+        long arrivalTimeMs,
+        long sendTime24bits,
+        int payloadSize,
+        long ssrc)
+    {
+        // Shift up send time to use the full 32 bits that inter_arrival
+        // works with, so wrapping works properly.
+        long timestamp = sendTime24bits << kAbsSendTimeInterArrivalUpshift;
+
+        // Convert the expanded AST (32 bits, 6.26 fixed point) to millis.
+        long sendTimeMs = (long) (timestamp * kTimestampToMs);
+
+        // XXX The arrival time should be the earliest we've seen this packet,
+        // not now. In our code however, we don't have access to the arrival
+        // time.
+        long nowMs = System.currentTimeMillis();
+
+        if (timeSeriesLogger.isTraceEnabled())
+        {
+            timeSeriesLogger.trace(diagnosticContext
+                .makeTimeSeriesPoint("in_pkt", nowMs)
+                .addField("rbe_id", hashCode())
+                .addField("recv_ts_ms", arrivalTimeMs)
+                .addField("send_ts_ms", sendTimeMs)
+                .addField("pkt_sz_bytes", payloadSize)
+                .addField("ssrc", ssrc));
+        }
+
+        // should be broken out from  here.
+        // Check if incoming bitrate estimate is valid, and if it
+        // needs to be reset.
+        long incomingBitrate_ = incomingBitrate.getRate(arrivalTimeMs);
+        if (incomingBitrate_ != 0)
+        {
+            incomingBitrateInitialized = true;
+        }
+        else if (incomingBitrateInitialized)
+        {
+            // Incoming bitrate had a previous valid value, but now not
+            // enough data point are left within the current window.
+            // Reset incoming bitrate estimator so that the window
+            // size will only contain new data points.
+            incomingBitrate = new RateStatistics(kBitrateWindowMs, kBitrateScale);
+            incomingBitrateInitialized = false;
+        }
+
+        incomingBitrate.update(payloadSize, arrivalTimeMs);
+
+        if (firstPacketTimeMs == -1)
+        {
+            firstPacketTimeMs = nowMs;
+        }
+
+        boolean updateEstimate = false;
+        long targetBitrateBps = 0;
+
+        synchronized (this)
+        {
+            timeoutStreams(nowMs);
+            ssrcsMap.put(ssrc, nowMs);
+            if (!ssrcs.contains(ssrc))
+            {
+                ssrcs = Collections.unmodifiableCollection(ssrcsMap.keySet());
+            }
+
+            long[] deltas = this.deltas;
+
+            /* long timestampDelta */ deltas[0] = 0;
+            /* long timeDelta */ deltas[1] = 0;
+            /* int sizeDelta */ deltas[2] = 0;
+
+            if (detector == null)
+            {
+                detector = new Detector(new OverUseDetectorOptions(), true);
+            }
+
+            if (detector.interArrival.computeDeltas(
+                timestamp, arrivalTimeMs, payloadSize, deltas, nowMs))
+            {
+                double tsDeltaMs = deltas[0] * kTimestampToMs;
+
+                detector.estimator.update(
+                    /* timeDelta */ deltas[1],
+                    /* timestampDelta */ tsDeltaMs,
+                    /* sizeDelta */ (int) deltas[2],
+                    detector.detector.getState(), nowMs);
+
+                detector.detector.detect(
+                    detector.estimator.getOffset(), tsDeltaMs,
+                    detector.estimator.getNumOfDeltas(), arrivalTimeMs);
+            }
+
+            // Check if it's time for a periodic update or if we
+            // should update because of an over-use.
+            if (lastUpdateMs == -1
+                || nowMs - lastUpdateMs > remoteRate.getFeedBackInterval())
+            {
+                updateEstimate = true;
+            }
+            else if (
+                detector.detector.getState() == BandwidthUsage.kBwOverusing)
+            {
+                long incomingRate_ = incomingBitrate.getRate(arrivalTimeMs);
+
+                if (incomingRate_ > 0 && remoteRate
+                    .isTimeToReduceFurther(nowMs, incomingBitrate_))
+                {
+                    updateEstimate = true;
+                }
+            }
+
+            if (updateEstimate)
+            {
+                // The first overuse should immediately trigger a new estimate.
+                // We also have to update the estimate immediately if we are
+                // overusing and the target bitrate is too high compared to
+                // what we are receiving.
+                input.bwState = detector.detector.getState();
+                input.incomingBitRate = incomingBitrate.getRate(arrivalTimeMs);
+                input.noiseVar = detector.estimator.getVarNoise();
+
+                remoteRate.update(input, nowMs);
+                targetBitrateBps = remoteRate.updateBandwidthEstimate(nowMs);
+                updateEstimate = remoteRate.isValidEstimate();
+            }
+        }
+
+        if (updateEstimate)
+        {
+            lastUpdateMs = nowMs;
+            if (observer != null)
+            {
+                observer.onReceiveBitrateChanged(getSsrcs(), targetBitrateBps);
+            }
+        }
+    }
+
+    /**
+     * Timeouts SSRCs that have not received any data for
+     * kTimestampGroupLengthMs millis.
+     *
+     * @param nowMs the current time in millis.
+     */
+    private synchronized void timeoutStreams(long nowMs)
+    {
+        boolean removed = false;
+        Iterator<Map.Entry<Long, Long>> itr = ssrcsMap.entrySet().iterator();
+        while (itr.hasNext())
+        {
+            Map.Entry<Long, Long> entry = itr.next();
+            if ((nowMs - entry.getValue() > kStreamTimeOutMs))
+            {
+                removed = true;
+                itr.remove();
+            }
+        }
+
+        if (removed)
+        {
+            ssrcs = Collections.unmodifiableCollection(ssrcsMap.keySet());
+        }
+
+        if (detector != null && ssrcsMap.isEmpty())
+        {
+            // We can't update the estimate if we don't have any active streams.
+            detector = null;
+            // We deliberately don't reset the first_packet_time_ms_
+            // here for now since we only probe for bandwidth in the
+            // beginning of a call right now.
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void onRttUpdate(long avgRttMs, long maxRttMs)
+    {
+        if (timeSeriesLogger.isTraceEnabled())
+        {
+            timeSeriesLogger.trace(diagnosticContext
+                .makeTimeSeriesPoint("new_rtt", System.currentTimeMillis())
+                .addField("avg_ms", avgRttMs)
+                .addField("max_ms", maxRttMs));
+        }
+
+        remoteRate.setRtt(avgRttMs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized long getLatestEstimate()
+    {
+        long bitrateBps;
+        if (!remoteRate.isValidEstimate())
+        {
+            return -1;
+        }
+        if (ssrcsMap.isEmpty())
+        {
+            bitrateBps = 0;
+        }
+        else
+        {
+            bitrateBps = remoteRate.getLatestEstimate();
+        }
+        return bitrateBps;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<Long> getSsrcs()
+    {
+        return ssrcs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void removeStream(long ssrc)
+    {
+        if (ssrcsMap.remove(ssrc) != null)
+        {
+            ssrcs = Collections.unmodifiableCollection(ssrcsMap.keySet());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void setMinBitrate(int minBitrateBps)
+    {
+        // Called from both the configuration thread and the network thread.
+        // Shouldn't be called from the network thread in the future.
+        remoteRate.setMinBitrate(minBitrateBps);
+    }
+
+    /**
+     * Holds the {@link InterArrival}, {@link OveruseEstimator} and
+     * {@link OveruseDetector} instances that estimate the remote bitrate of a
+     * stream.
+     */
+    private class Detector
+    {
+        /**
+         * Computes the send-time and recv-time deltas to feed to the estimator.
+         */
+        private InterArrival interArrival;
+
+        /**
+         * The Kalman filter implementation that estimates the jitter.
+         */
+        private OveruseEstimator estimator;
+
+        /**
+         * The overuse detector that compares the jitter to an adaptive threshold.
+         */
+        private final OveruseDetector detector;
+
+        /**
+         * Ctor.
+         *
+         * @param options the over-use detector options.
+         * @param enableBurstGrouping true to activate burst detection, false
+         * otherwise
+         */
+        Detector(OverUseDetectorOptions options,
+                 boolean enableBurstGrouping)
+        {
+            this.interArrival = new InterArrival(
+                kTimestampGroupLengthTicks, kTimestampToMs,
+                enableBurstGrouping, diagnosticContext);
+            this.estimator = new OveruseEstimator(options, diagnosticContext);
+            this.detector = new OveruseDetector(options, diagnosticContext);
+        }
+    }
+
+    /**
+     * Converts rtp timestamps to 24bit timestamp equivalence
+     * @param timeMs is the RTP timestamp e.g System.currentTimeMillis().
+     * @return time stamp representation in 24 bit representation.
+     */
+    public static long convertMsTo24Bits(long timeMs)
+    {
+        return (((timeMs << kAbsSendTimeFraction) + 500) / 1000) & 0x00FFFFFF;
+    }
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -18,7 +18,10 @@ package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jetbrains.annotations.*;
 import org.jitsi_modified.service.neomedia.rtp.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging.TimeSeriesLogger;
+import org.jitsi.utils.logging2.*;
+
 import org.jitsi.utils.stats.*;
 
 import java.util.*;
@@ -159,6 +162,11 @@ public class RemoteBitrateEstimatorAbsSendTime
      */
     private final DiagnosticContext diagnosticContext;
 
+     /**
+      * The instance logger.
+      */
+    private final Logger logger;
+
     /**
      * Ctor.
      *
@@ -167,8 +175,10 @@ public class RemoteBitrateEstimatorAbsSendTime
      */
     public RemoteBitrateEstimatorAbsSendTime(
             RemoteBitrateObserver observer,
-            @NotNull DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext,
+            @NotNull Logger parentLogger)
     {
+        this.logger = parentLogger.createChildLogger(getClass().getName());
         this.observer = observer;
         this.diagnosticContext = diagnosticContext;
         this.remoteRate = new AimdRateControl(diagnosticContext);
@@ -262,7 +272,7 @@ public class RemoteBitrateEstimatorAbsSendTime
 
             if (detector == null)
             {
-                detector = new Detector(new OverUseDetectorOptions(), true);
+                detector = new Detector(new OverUseDetectorOptions(), true, logger);
             }
 
             if (detector.interArrival.computeDeltas(
@@ -461,13 +471,14 @@ public class RemoteBitrateEstimatorAbsSendTime
          * otherwise
          */
         Detector(OverUseDetectorOptions options,
-                 boolean enableBurstGrouping)
+                 boolean enableBurstGrouping,
+                 Logger parentLogger)
         {
             this.interArrival = new InterArrival(
                 kTimestampGroupLengthTicks, kTimestampToMs,
-                enableBurstGrouping, diagnosticContext);
-            this.estimator = new OveruseEstimator(options, diagnosticContext);
-            this.detector = new OveruseDetector(options, diagnosticContext);
+                enableBurstGrouping, diagnosticContext, parentLogger);
+            this.estimator = new OveruseEstimator(options, diagnosticContext, logger);
+            this.detector = new OveruseDetector(options, diagnosticContext, logger);
         }
     }
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 
-import org.jitsi.service.neomedia.rtp.*;
 import org.jetbrains.annotations.*;
+import org.jitsi_modified.service.neomedia.rtp.*;
 import org.jitsi.utils.logging.*;
 import org.jitsi.utils.stats.*;
 
@@ -362,9 +362,8 @@ public class RemoteBitrateEstimatorAbsSendTime
     }
 
     /**
-     * {@inheritDoc}
+     * Called when an RTP sender has a new round-trip time estimate.
      */
-    @Override
     public synchronized void onRttUpdate(long avgRttMs, long maxRttMs)
     {
         if (timeSeriesLogger.isTraceEnabled())

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateObserver.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateObserver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+
+import java.util.*;
+
+/**
+ * <tt>RemoteBitrateObserver</tt> is used to signal changes in bitrate estimates
+ * for the incoming streams.
+ *
+ * webrtc/modules/remote_bitrate_estimator/include/remote_bitrate_estimator.h
+ *
+ * @author Lyubomir Marinov
+ */
+public interface RemoteBitrateObserver
+{
+    /**
+     * Called when a receive channel group has a new bitrate estimate for the
+     * incoming streams.
+     *
+     * @param ssrcs
+     * @param bitrate
+     */
+    void onReceiveBitrateChanged(Collection<Long> ssrcs, long bitrate);
+}

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateObserver.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateObserver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
 import java.util.*;
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -23,7 +23,8 @@ import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
 
 import org.jitsi.utils.concurrent.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging2.*;
 import org.jitsi_modified.service.neomedia.rtp.*;
 
 import java.util.*;
@@ -88,10 +89,12 @@ public class BandwidthEstimatorImpl
      * Initializes a new instance which is to belong to a particular
      * {@link MediaStream}.
      */
-    public BandwidthEstimatorImpl(DiagnosticContext diagnosticContext)
+    public BandwidthEstimatorImpl(DiagnosticContext diagnosticContext,
+        @NotNull Logger parentLogger)
     {
         sendSideBandwidthEstimation
-            = new SendSideBandwidthEstimation(diagnosticContext, START_BITRATE_BPS);
+            = new SendSideBandwidthEstimation(diagnosticContext,
+                START_BITRATE_BPS, parentLogger);
         sendSideBandwidthEstimation.setMinMaxBitrate(
                 MIN_BITRATE_BPS, MAX_BITRATE_BPS);
     }

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -16,7 +16,7 @@
 package org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation;
 
 import org.jetbrains.annotations.*;
-import org.jitsi.impl.neomedia.rtp.remotebitrateestimator.*;
+import org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator.*;
 import org.jitsi.rtp.rtcp.*;
 
 import org.jitsi.service.configuration.*;
@@ -244,7 +244,7 @@ public class BandwidthEstimatorImpl
 
     /**
      * This is hooked up to the
-     * {@link org.jitsi.service.neomedia.rtp.RemoteBitrateEstimator} in
+     * {@link org.jitsi_modified.service.neomedia.rtp.RemoteBitrateEstimator} in
      * {@link org.jitsi_modified.impl.neomedia.rtp.TransportCCEngine}, which
      * performs the delay-based estimation (also referred to as
      * "receiver estimate").

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -15,9 +15,12 @@
  */
 package org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
-import org.jitsi.utils.logging.*;
+import org.jitsi.utils.logging.DiagnosticContext;
+import org.jitsi.utils.logging.TimeSeriesLogger;
+import org.jitsi.utils.logging2.*;
 import org.jitsi_modified.service.neomedia.rtp.BandwidthEstimator;
 
 import java.util.*;
@@ -162,11 +165,9 @@ class SendSideBandwidthEstimation
     private static final Random kRandom = new Random();
 
     /**
-     * The <tt>Logger</tt> used by the {@link SendSideBandwidthEstimation} class
-     * and its instances for logging output.
+     * The <tt>Logger</tt> used by this instance for logging output.
      */
-    private static final Logger logger
-            = Logger.getLogger(SendSideBandwidthEstimation.class);
+    private final Logger logger;
 
     /**
      * The {@link TimeSeriesLogger} to be used by this instance to print time
@@ -286,8 +287,10 @@ class SendSideBandwidthEstimation
      */
     private final StatisticsImpl statistics = new StatisticsImpl();
 
-    SendSideBandwidthEstimation(DiagnosticContext diagnosticContext, long startBitrate)
+    SendSideBandwidthEstimation(DiagnosticContext diagnosticContext, long startBitrate,
+        @NotNull Logger parentLogger)
     {
+        logger = parentLogger.createChildLogger(getClass().getName());
         this.diagnosticContext = diagnosticContext;
 
         float lossExperimentProbability = (float) cfg.getDouble(

--- a/src/main/java/org/jitsi_modified/service/neomedia/rtp/BandwidthEstimator.java
+++ b/src/main/java/org/jitsi_modified/service/neomedia/rtp/BandwidthEstimator.java
@@ -62,7 +62,7 @@ public interface BandwidthEstimator
 
     /**
      * @return the latest effective fraction loss calculated by this
-     * {@link org.jitsi.service.neomedia.rtp.BandwidthEstimator}. The value is between 0 and 256 (corresponding
+     * {@link org.jitsi_modified.service.neomedia.rtp.BandwidthEstimator}. The value is between 0 and 256 (corresponding
      * to 0% and 100% respectively).
      */
     int getLatestFractionLoss();

--- a/src/main/java/org/jitsi_modified/service/neomedia/rtp/RemoteBitrateEstimator.java
+++ b/src/main/java/org/jitsi_modified/service/neomedia/rtp/RemoteBitrateEstimator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.service.neomedia.rtp;
+
+import org.jitsi.service.neomedia.*;
+
+import java.util.*;
+
+/**
+ * webrtc/modules/remote_bitrate_estimator/include/remote_bitrate_estimator.cc
+ * webrtc/modules/remote_bitrate_estimator/include/remote_bitrate_estimator.h
+ *
+ * @author Lyubomir Marinov
+ */
+public interface RemoteBitrateEstimator
+    extends CallStatsObserver
+{
+    /**
+     * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h
+     */
+    int kBitrateWindowMs = 1000;
+
+    int kBitrateScale = 8000;
+
+    int kDefaultMinBitrateBps = 30000;
+
+    int kProcessIntervalMs = 500;
+
+    int kStreamTimeOutMs = 2000;
+
+    int kTimestampGroupLengthMs = 5;
+
+    /**
+     * Returns the estimated payload bitrate in bits per second if a valid
+     * estimate exists; otherwise, <tt>-1</tt>.
+     *
+     * @return the estimated payload bitrate in bits per seconds if a valid
+     * estimate exists; otherwise, <tt>-1</tt>
+     */
+    long getLatestEstimate();
+
+    /**
+     * Returns the estimated payload bitrate in bits per second if a valid
+     * estimate exists; otherwise, <tt>-1</tt>.
+     *
+     * @return the estimated payload bitrate in bits per seconds if a valid
+     * estimate exists; otherwise, <tt>-1</tt>
+     */
+    Collection<Long> getSsrcs();
+
+    /**
+     * Removes all data for <tt>ssrc</tt>.
+     *
+     * @param ssrc
+     */
+    void removeStream(long ssrc);
+
+    /**
+     * Sets the minimum bitrate for this instance.
+     *
+     * @param minBitrateBps the minimum bitrate in bps.
+     */
+    void setMinBitrate(int minBitrateBps);
+
+    /**
+     * Notifies this instance of an incoming packet.
+     *
+     * @param arrivalTimeMs the arrival time of the packet in millis.
+     * @param timestamp the 32bit send timestamp of the packet. Note that the
+     * specific format depends on the specific implementation.
+     * @param payloadSize the payload size of the packet.
+     * @param ssrc the SSRC of the packet.
+     */
+    void incomingPacketInfo(
+        long arrivalTimeMs, long timestamp, int payloadSize, long ssrc);
+}

--- a/src/main/java/org/jitsi_modified/service/neomedia/rtp/RemoteBitrateEstimator.java
+++ b/src/main/java/org/jitsi_modified/service/neomedia/rtp/RemoteBitrateEstimator.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.service.neomedia.rtp;
-
-import org.jitsi.service.neomedia.*;
+package org.jitsi_modified.service.neomedia.rtp;
 
 import java.util.*;
 
@@ -26,7 +24,6 @@ import java.util.*;
  * @author Lyubomir Marinov
  */
 public interface RemoteBitrateEstimator
-    extends CallStatsObserver
 {
     /**
      * webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -82,9 +82,9 @@ class Transceiver(
 
     private var mediaStreamTracks = MediaStreamTracks()
 
-    private val bandwidthEstimator: BandwidthEstimatorImpl = BandwidthEstimatorImpl(diagnosticContext)
+    private val bandwidthEstimator: BandwidthEstimatorImpl = BandwidthEstimatorImpl(diagnosticContext, logger)
 
-    private val transportCcEngine = TransportCCEngine(diagnosticContext, bandwidthEstimator)
+    private val transportCcEngine = TransportCCEngine(diagnosticContext, bandwidthEstimator, logger)
 
     private val rtpSender: RtpSender = RtpSenderImpl(
         id,


### PR DESCRIPTION
This imports those parts of bandwidth estimation used by jmt.  It does *not* import the parts jmt is not currently using, notably those used only by REMB.