### PR TITLE
Set the start bitrate to 2.5Mbps

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/TransportCCEngine.java
@@ -27,9 +27,8 @@ import org.jitsi.utils.logging2.*;
 import java.util.*;
 
 /**
- * Implements transport-cc functionality as a {@link TransformEngine}. The
- * intention is to have the same instance shared between all media streams of
- * a transport channel, so we expect it will be accessed by multiple threads.
+ * Implements transport-cc functionality.
+ *
  * See https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
  *
  * @author Boris Grozev

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -70,7 +70,7 @@ public class BandwidthEstimatorImpl
      * The initial value of the estimation, in bits per second.
      */
     private static final long START_BITRATE_BPS
-        = cfg != null ? cfg.getLong(START_BITRATE_BPS_PNAME, 300000) : 300000;
+        = cfg != null ? cfg.getLong(START_BITRATE_BPS_PNAME, 2500000) : 2500000;
 
     /**
      * bitrate_controller_impl.h

--- a/src/main/java/org/jitsi_modified/service/neomedia/rtp/BandwidthEstimator.java
+++ b/src/main/java/org/jitsi_modified/service/neomedia/rtp/BandwidthEstimator.java
@@ -62,7 +62,7 @@ public interface BandwidthEstimator
 
     /**
      * @return the latest effective fraction loss calculated by this
-     * {@link org.jitsi_modified.service.neomedia.rtp.BandwidthEstimator}. The value is between 0 and 256 (corresponding
+     * {@link BandwidthEstimator}. The value is between 0 and 256 (corresponding
      * to 0% and 100% respectively).
      */
     int getLatestFractionLoss();


### PR DESCRIPTION
Jitsi-videobridge sets the [start bitrate to 2.5Mbps using a property](https://github.com/jitsi/jitsi-videobridge/blob/master/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java#L145). This PR switches the default value, so that we can remove this code from the bridge (in jitsi/jitsi-videobridge#901).