### PR TITLE
Index EndpointConnectionStats.srSendTimes by (ssrc, lastSrTimestamp).

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -25,7 +25,6 @@ import org.jitsi.rtp.rtcp.RtcpRrPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
 import org.jitsi.utils.LRUCache
 import org.jitsi.utils.logging2.Logger
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -33,7 +32,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 private const val MAX_SR_TIMESTAMP_HISTORY = 200
 
-private typealias SsrcAndTimestamp = Pair<Long,Long>
+private typealias SsrcAndTimestamp = Pair<Long, Long>
 
 /**
  * Tracks stats which are not necessarily tied to send or receive but the endpoint overall
@@ -48,7 +47,6 @@ class EndpointConnectionStats(
         val rtt: Double
     )
     private val endpointConnectionStatsListeners: MutableList<EndpointConnectionStatsListener> = CopyOnWriteArrayList()
-
 
     // Per-SSRC, maps the compacted NTP timestamp found in an SR SenderInfo to
     //  the clock time (in milliseconds) at which it was transmitted

--- a/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -23,9 +23,16 @@ import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtcp.RtcpReportBlock
 import org.jitsi.rtp.rtcp.RtcpRrPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
+import org.jitsi.utils.LRUCache
 import org.jitsi.utils.logging2.Logger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * The maximum number of SR packets and their timestamps to save.
+ */
+private const val MAX_SR_TIMESTAMP_HISTORY = 200
+
 
 /**
  * Tracks stats which are not necessarily tied to send or receive but the endpoint overall
@@ -43,7 +50,7 @@ class EndpointConnectionStats(
 
     // Maps the compacted NTP timestamp found in an SR SenderInfo to the clock time (in milliseconds)
     //  at which it was transmitted
-    private val srSentTimes: MutableMap<Long, Long> = ConcurrentHashMap()
+    private val srSentTimes: MutableMap<Pair<Long,Long>, Long> = LRUCache(MAX_SR_TIMESTAMP_HISTORY)
     private val logger = parentLogger.createChildLogger(EndpointConnectionStats::class)
 
     /**
@@ -78,7 +85,7 @@ class EndpointConnectionStats(
         when (packet) {
             is RtcpSrPacket -> {
                 logger.cdebug { "Tracking sent SR packet with compacted timestamp ${packet.senderInfo.compactedNtpTimestamp}" }
-                srSentTimes[packet.senderInfo.compactedNtpTimestamp] =
+                srSentTimes[Pair(packet.senderSsrc, packet.senderInfo.compactedNtpTimestamp)] =
                         System.currentTimeMillis()
             }
         }
@@ -87,7 +94,7 @@ class EndpointConnectionStats(
     private fun processReportBlock(receivedTime: Long, reportBlock: RtcpReportBlock) {
         if (reportBlock.lastSrTimestamp > 0 && reportBlock.delaySinceLastSr > 0) {
             // We need to know when we sent the last SR
-            val srSentTime = srSentTimes.getOrDefault(reportBlock.lastSrTimestamp, -1)
+            val srSentTime = srSentTimes.getOrDefault(Pair(reportBlock.ssrc, reportBlock.lastSrTimestamp), -1)
             if (srSentTime > 0) {
                 // The delaySinceLastSr value is given in 1/65536ths of a second, so divide it by 65.536 to get it
                 // in milliseconds


### PR DESCRIPTION
Use an LRUCache for srSendTimes.