### PR TITLE
Fixed NPE due to String! to String conversion.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/MediaStreamTracks.kt
+++ b/src/main/kotlin/org/jitsi/nlj/MediaStreamTracks.kt
@@ -63,7 +63,7 @@ class MediaStreamTracks : NodeStatsProducer {
     override fun getNodeStats(): NodeStatsBlock = NodeStatsBlock("MediaStreamTracks").apply {
         tracks.forEachIndexed { i, track ->
             val trackBlock = NodeStatsBlock("track_$i")
-            trackBlock.addString("owner", track.owner)
+            track.owner?.let { trackBlock.addString("owner", it) }
             track.rtpEncodings.forEach { trackBlock.addBlock(it.getNodeStats()) }
             addBlock(trackBlock)
         }


### PR DESCRIPTION
[`track.owner`](https://github.com/jitsi/jitsi-media-transform/blob/e1c357d1dae88b39c949f04dc71c122636706353/src/main/java/org/jitsi_modified/impl/neomedia/rtp/MediaStreamTrackDesc.java#L50) type has platform type `String!` which [can be null](https://github.com/jitsi/jitsi-media-transform/blob/e1c357d1dae88b39c949f04dc71c122636706353/src/main/java/org/jitsi_modified/impl/neomedia/rtp/MediaStreamTrackDesc.java#L61). It might crash in runtime (crashed in my environment).