### PR TITLE
Use 'stubOnly = true' for Mockito in BandwidthEstimationTest.

### DIFF
--- a/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
@@ -1,7 +1,5 @@
 package org.jitsi.nlj.rtp.bandwidthestimation
 
-import com.nhaarman.mockitokotlin2.UseConstructor
-import com.nhaarman.mockitokotlin2.mock
 import io.kotlintest.matchers.doubles.shouldBeBetween
 import io.kotlintest.specs.ShouldSpec
 import java.time.Clock
@@ -14,6 +12,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import kotlin.properties.Delegates
 import org.jitsi.nlj.test_utils.FakeScheduledExecutorService
+import org.jitsi.nlj.test_utils.stubOnlySpy
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
 import org.jitsi.nlj.util.NEVER
@@ -26,7 +25,6 @@ import org.jitsi.service.libjitsi.LibJitsi
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.LoggerImpl
-import org.mockito.Mockito.CALLS_REAL_METHODS
 
 /** A simulated packet, for bandwidth estimation testing. */
 data class SimulatedPacket(
@@ -194,7 +192,7 @@ class BandwidthEstimationTest : ShouldSpec() {
         /* Internals of GoogleCc use ConfigurationService at construct time. */
         LibJitsi.start()
     }
-    private val scheduler: FakeScheduledExecutorService = mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = CALLS_REAL_METHODS)
+    private val scheduler: FakeScheduledExecutorService = stubOnlySpy()
     private val clock: Clock = scheduler.clock
 
     private val ctx = DiagnosticContext(clock)

--- a/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
@@ -1,6 +1,7 @@
 package org.jitsi.nlj.rtp.bandwidthestimation
 
-import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.UseConstructor
+import com.nhaarman.mockitokotlin2.mock
 import io.kotlintest.matchers.doubles.shouldBeBetween
 import io.kotlintest.specs.ShouldSpec
 import java.time.Clock
@@ -25,6 +26,7 @@ import org.jitsi.service.libjitsi.LibJitsi
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.LoggerImpl
+import org.mockito.Mockito.CALLS_REAL_METHODS
 
 /** A simulated packet, for bandwidth estimation testing. */
 data class SimulatedPacket(
@@ -192,7 +194,7 @@ class BandwidthEstimationTest : ShouldSpec() {
         /* Internals of GoogleCc use ConfigurationService at construct time. */
         LibJitsi.start()
     }
-    private val scheduler: FakeScheduledExecutorService = spy()
+    private val scheduler: FakeScheduledExecutorService = mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = CALLS_REAL_METHODS)
     private val clock: Clock = scheduler.clock
 
     private val ctx = DiagnosticContext(clock)

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeExecutorService.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeExecutorService.kt
@@ -1,17 +1,15 @@
 package org.jitsi.nlj.test_utils
 
-import com.nhaarman.mockitokotlin2.UseConstructor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
-import org.mockito.Mockito.CALLS_REAL_METHODS
 
 internal abstract class FakeExecutorService : ExecutorService {
     private var jobs = JobsTimeline()
-    val clock: FakeClock = mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = CALLS_REAL_METHODS)
+    val clock: FakeClock = stubOnlySpy()
 
     override fun execute(command: Runnable) {
         jobs.add(Job(command, clock.instant()))

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeExecutorService.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeExecutorService.kt
@@ -1,23 +1,24 @@
 package org.jitsi.nlj.test_utils
 
+import com.nhaarman.mockitokotlin2.UseConstructor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import org.mockito.Mockito.CALLS_REAL_METHODS
 
 internal abstract class FakeExecutorService : ExecutorService {
     private var jobs = JobsTimeline()
-    val clock: FakeClock = spy()
+    val clock: FakeClock = mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = CALLS_REAL_METHODS)
 
     override fun execute(command: Runnable) {
         jobs.add(Job(command, clock.instant()))
     }
 
     override fun submit(task: Runnable): Future<*> {
-        val future: CompletableFuture<Unit> = mock()
+        val future: CompletableFuture<Unit> = mock(stubOnly = true)
         val job = Job(task, clock.instant())
         whenever(future.cancel(any())).thenAnswer {
             job.cancelled = true

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeScheduledExecutorService.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeScheduledExecutorService.kt
@@ -1,6 +1,5 @@
 package org.jitsi.nlj.test_utils
 
-import com.nhaarman.mockitokotlin2.UseConstructor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -9,7 +8,6 @@ import java.time.Instant
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
-import org.mockito.Mockito.CALLS_REAL_METHODS
 
 /**
  * A fake [ScheduledExecutorService] which gives control over when scheduled tasks are running without requiring a
@@ -17,7 +15,7 @@ import org.mockito.Mockito.CALLS_REAL_METHODS
  */
 internal abstract class FakeScheduledExecutorService : ScheduledExecutorService {
     private var jobs = JobsTimeline()
-    val clock: FakeClock = mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = CALLS_REAL_METHODS)
+    val clock: FakeClock = stubOnlySpy()
 
     override fun scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit): ScheduledFuture<*> {
         val future: ScheduledFuture<Unit> = mock(stubOnly = true)

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeScheduledExecutorService.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeScheduledExecutorService.kt
@@ -1,14 +1,15 @@
 package org.jitsi.nlj.test_utils
 
+import com.nhaarman.mockitokotlin2.UseConstructor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import org.mockito.Mockito.CALLS_REAL_METHODS
 
 /**
  * A fake [ScheduledExecutorService] which gives control over when scheduled tasks are running without requiring a
@@ -16,10 +17,10 @@ import java.util.concurrent.TimeUnit
  */
 internal abstract class FakeScheduledExecutorService : ScheduledExecutorService {
     private var jobs = JobsTimeline()
-    val clock: FakeClock = spy()
+    val clock: FakeClock = mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = CALLS_REAL_METHODS)
 
     override fun scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit): ScheduledFuture<*> {
-        val future: ScheduledFuture<Unit> = mock()
+        val future: ScheduledFuture<Unit> = mock(stubOnly = true)
         val nextRunTime = clock.instant().plus(Duration.ofMillis(unit.toMillis(initialDelay)))
         val job = RecurringJob(command, nextRunTime, Duration.ofMillis(unit.toMillis(period)))
         jobs.add(job)
@@ -34,7 +35,7 @@ internal abstract class FakeScheduledExecutorService : ScheduledExecutorService 
 
     override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> {
 //        println("scheduling job with a delay of $delay $unit from time ${clock.instant()}")
-        val future: ScheduledFuture<Unit> = mock()
+        val future: ScheduledFuture<Unit> = mock(stubOnly = true)
         val nextRunTime = clock.instant().plus(Duration.ofNanos(unit.toNanos(delay)))
         val job = Job(command, nextRunTime)
         jobs.add(job)

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/MockitoUtils.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/MockitoUtils.kt
@@ -1,0 +1,12 @@
+package org.jitsi.nlj.test_utils
+
+import com.nhaarman.mockitokotlin2.UseConstructor
+import com.nhaarman.mockitokotlin2.mock
+import org.mockito.Mockito
+
+/**
+ * Like Mockito spy(), but with stubOnly set to avoid excessive memory consumption.
+ */
+inline fun <reified T : Any> stubOnlySpy(): T {
+    return mock(stubOnly = true, useConstructor = UseConstructor.parameterless(), defaultAnswer = Mockito.CALLS_REAL_METHODS)
+}


### PR DESCRIPTION
Otherwise the test consumes a huge amount of memory (gigabytes) and takes a long time.