### PR TITLE
ignore import-ordering ktlint rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*.{kt,kts}]
+# Comma-separated list of rules to disable (Since 0.34.0)
+# Note that rules in any ruleset other than the standard ruleset will need to be prefixed 
+# by the ruleset identifier.
+# intellij currently has no setting to set sort order, and its
+# default behavior directly contradicts what this rule wants. see
+# https://youtrack.jetbrains.com/issue/KT-10974
+disabled_rules=import-ordering


### PR DESCRIPTION
intellij currently has no setting to enable this behavior, and its
default behavior directly contradicts this rule.  see
https://youtrack.jetbrains.com/issue/KT-10974