### PR TITLE
Rtcp sr forwarding fix

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -19,17 +19,17 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.TransformerNode
-import org.jitsi.nlj.util.BufferPool
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.cinfo
 import org.jitsi.nlj.util.createChildLogger
 import org.jitsi.rtp.rtcp.CompoundRtcpPacket
 import org.jitsi.rtp.rtcp.RtcpByePacket
+import org.jitsi.rtp.rtcp.RtcpHeader
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtcp.RtcpRrPacket
 import org.jitsi.rtp.rtcp.RtcpSdesPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
-import org.jitsi.rtp.rtcp.RtcpSrPacketBuilder
+import org.jitsi.rtp.rtcp.SenderInfoParser
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbFirPacket
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.RtcpFbNackPacket
@@ -79,20 +79,19 @@ class RtcpTermination(
             packetReceiveCounts.merge(rtcpPacket::class.simpleName!!, 1, Int::plus)
             rtcpEventNotifier.notifyRtcpReceived(rtcpPacket, packetInfo.receivedTime)
 
-            (forwardedRtcp as? RtcpSrPacket)?.let {
+            if (rtcpPacket is RtcpSrPacket) {
                 // NOTE(george) effectively eliminates any report blocks as we don't want to relay those
-                logger.cdebug { "Saw an sr from ssrc=${rtcpPacket.senderSsrc}, timestamp=${it.senderInfo.rtpTimestamp}" }
-                forwardedRtcp = it.cloneWithoutReportBlocks()
+                logger.cdebug { "Saw an sr from ssrc=${rtcpPacket.senderSsrc}, timestamp=${rtcpPacket.senderInfo.rtpTimestamp}" }
+                val lengthBytes = RtcpHeader.SIZE_BYTES + SenderInfoParser.SIZE_BYTES
+                rtcpPacket.length = lengthBytes
+                // We can do this because we've already parsed the compound packet and we are discarding it anyway
+                rtcpPacket.lengthField = (lengthBytes / 4) - 1
+                rtcpPacket.reportCount = 0
             }
         }
         return if (forwardedRtcp != null) {
             // Manually cast to RtcpPacket as a workaround for https://youtrack.jetbrains.com/issue/KT-7186
             packetInfo.packet = forwardedRtcp as RtcpPacket
-            if (forwardedRtcp is RtcpSrPacket) {
-                // If we forwarded an SR, we cloned it to strip the report blocks
-                // so we can return the original buffer
-                BufferPool.returnBuffer(packetInfo.packet.buffer)
-            }
             packetInfo
         } else {
             packetDiscarded(packetInfo)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -61,7 +61,7 @@ class RtcpTermination(
                     // we want to forward in the same compound packet.  If we can, then we may need
                     // to turn this into a MultipleOutputNode
                     forwardedRtcp?.let {
-                        logger.cinfo { "Failed to forward a packet of type ${forwardedRtcp!!::class.simpleName} " +
+                        logger.cinfo { "Failed to forward a packet of type ${it::class.simpleName} " +
                             ". Replaced by ${rtcpPacket::class.simpleName}." }
                         numFailedToForward++
                     }

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.transform.node.incoming
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.kotlintest.IsolationMode
+import io.kotlintest.specs.ShouldSpec
+import io.kotlintest.shouldBe
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.resources.logging.StdoutLogger
+import org.jitsi.nlj.resources.node.onOutput
+import org.jitsi.nlj.rtcp.RtcpEventNotifier
+import org.jitsi.rtp.rtcp.CompoundRtcpPacket
+import org.jitsi.rtp.rtcp.RtcpHeader
+import org.jitsi.rtp.rtcp.RtcpHeaderBuilder
+import org.jitsi.rtp.rtcp.RtcpPacket
+import org.jitsi.rtp.rtcp.RtcpReportBlock
+import org.jitsi.rtp.rtcp.RtcpSrPacket
+import org.jitsi.rtp.rtcp.RtcpSrPacketBuilder
+import org.jitsi.rtp.rtcp.SenderInfoBuilder
+import org.jitsi.rtp.rtcp.SenderInfoParser
+
+class RtcpTerminationTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    private val rtcpEventNotifier: RtcpEventNotifier = mock()
+    private val rtcpTermination = RtcpTermination(rtcpEventNotifier, StdoutLogger())
+
+    init {
+        "An SR packet" {
+            val senderInfo = SenderInfoBuilder(
+                ntpTimestampMsw = 0xDEADBEEF,
+                ntpTimestampLsw = 0xBEEFDEAD,
+                rtpTimestamp = 12345L,
+                sendersPacketCount = 42,
+                sendersOctetCount = 4242
+            )
+            "with a receiver report block" {
+                val reportBlock = RtcpReportBlock(
+                    ssrc = 12345,
+                    fractionLost = 42,
+                    cumulativePacketsLost = 4242,
+                    seqNumCycles = 1,
+                    seqNum = 42,
+                    interarrivalJitter = 4242,
+                    lastSrTimestamp = 23456,
+                    delaySinceLastSr = 34567
+                )
+
+                val srPacket = RtcpSrPacketBuilder(
+                    RtcpHeaderBuilder(
+                        senderSsrc = 12345L
+                    ),
+                    senderInfo,
+                    mutableListOf(reportBlock)
+                ).build()
+
+                val compoundRtcpPacket = CompoundRtcpPacket(srPacket.buffer, srPacket.offset, srPacket.length)
+
+                whenever(rtcpEventNotifier.notifyRtcpReceived(any<RtcpPacket>(), any())).thenAnswer {
+                    (it.getArgument(0) as RtcpSrPacket).reportBlocks
+                }
+
+                should("remove all of the report blocks") {
+                    rtcpTermination.onOutput { packetInfo ->
+                        println(packetInfo)
+                        with (packetInfo.packet as RtcpSrPacket) {
+                            length shouldBe (RtcpHeader.SIZE_BYTES + SenderInfoParser.SIZE_BYTES)
+                            reportCount shouldBe 0
+                            reportBlocks.size shouldBe 0
+                        }
+                    }
+                    rtcpTermination.processPacket(PacketInfo(compoundRtcpPacket))
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
@@ -79,8 +79,7 @@ class RtcpTerminationTest : ShouldSpec() {
 
                 should("remove all of the report blocks") {
                     rtcpTermination.onOutput { packetInfo ->
-                        println(packetInfo)
-                        with (packetInfo.packet as RtcpSrPacket) {
+                        with(packetInfo.packet as RtcpSrPacket) {
                             length shouldBe (RtcpHeader.SIZE_BYTES + SenderInfoParser.SIZE_BYTES)
                             reportCount shouldBe 0
                             reportBlocks.size shouldBe 0


### PR DESCRIPTION
Fixing this had a bit of baggage.  The rtcp packet types were intentionally written to be immutable (at least for the non-fixed-sized fields) because it simplified things a lot.  So modifying `reportCount` directly worked fine, but, since `reportBlocks` is a lazy property and is based on the value of `reportCount`, if it had already been accessed (which it would’ve been by the time we change these fields), then it’s a bit of a potential time-bomb, I worried, since it would be inconsistent with an updated value of `reportCount`.  So I considered the following approaches to address this:

1. Just set `reportCount` and take our chances that the inconsistency between it and `reportBlocks` doesn’t bite us
2. Make `reportBlocks` a non-lazy property (i.e. read it every time).  This fixes the issue, but is inconsistent with the whole immutable idea and a bit more work to redo the parse on every access.
3. Add a `cloneWithoutReportBlocks` (or another name) method for `RtcpSrPacket` which does what the name suggests.  This preserves the immutability, but we need to do the work of copying the data into a new buffer.

I'd like option 3 the best, so gave that a shot.  I figured we'd see how it went and address any perf issue with the extra copy down the line. However, I found it has a gotcha as well: if we end up cloning the SR packet, then we need to return the original packet's buffer back to the pool.  Moreso, technically we only need to clone the SR packet here if it had report blocks in it.  We could do this and get it right, I think, but it felt a bit brittle so I abandoned it and went with option 2 (the commit which implements option 3--though without the optimization for not cloning if no report blocks are present--can be seen in the commits here.

Open to other ideas/feedback on this--maybe there's a better compromise I missed.

Relies on https://github.com/jitsi/jitsi-rtp/pull/48 (will need a pom update once that is in)