### PR TITLE
Packet activity updates

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -128,7 +128,7 @@ class Transceiver(
      * this transceiver is associated with) to be processed by the receiver pipeline.
      */
     fun handleIncomingPacket(p: PacketInfo) {
-        packetIOActivity.lastPacketReceivedTimestampMs = System.currentTimeMillis()
+        packetIOActivity.lastRtpPacketReceivedTimestamp = clock.instant()
         rtpReceiver.enqueuePacket(p)
     }
 
@@ -137,7 +137,7 @@ class Transceiver(
      * passing them out the sender's outgoing pipeline
      */
     fun sendPacket(packetInfo: PacketInfo) {
-        packetIOActivity.lastPacketSentTimestampMs = System.currentTimeMillis()
+        packetIOActivity.lastRtpPacketSentTimestamp = clock.instant()
         rtpSender.processPacket(packetInfo)
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -66,7 +66,8 @@ class Transceiver(
      */
     backgroundExecutor: ScheduledExecutorService,
     diagnosticContext: DiagnosticContext,
-    parentLogger: Logger
+    parentLogger: Logger,
+    private val clock: Clock = Clock.systemUTC()
 ) : Stoppable, NodeStatsProducer {
     private val logger = parentLogger.createChildLogger(Transceiver::class)
     val packetIOActivity = PacketIOActivity()
@@ -257,7 +258,7 @@ class Transceiver(
             addBlock(streamInformationStore.getNodeStats())
             addBlock(mediaStreamTracks.getNodeStats())
             addString("endpointConnectionStats", endpointConnectionStats.getSnapshot().toString())
-            addJson("Bandwidth Estimation", bandwidthEstimator.getStats(Clock.systemUTC().instant()).toJson())
+            addJson("Bandwidth Estimation", bandwidthEstimator.getStats(clock.instant()).toJson())
             addBlock(rtpReceiver.getNodeStats())
             addBlock(rtpSender.getNodeStats())
         }
@@ -273,7 +274,7 @@ class Transceiver(
             rtpReceiver.getPacketStreamStats(),
             rtpSender.getStreamStats(),
             rtpSender.getPacketStreamStats(),
-            bandwidthEstimator.getStats(Clock.systemUTC().instant()))
+            bandwidthEstimator.getStats(clock.instant()))
     }
 
     override fun stop() {

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
@@ -19,11 +19,18 @@ package org.jitsi.nlj.stats
 import org.jitsi.nlj.util.NEVER
 import org.jitsi.nlj.util.latest
 import java.time.Instant
+import kotlin.properties.Delegates.vetoable
 
 class PacketIOActivity {
-    var lastRtpPacketReceivedTimestamp: Instant = NEVER
-    var lastRtpPacketSentTimestamp: Instant = NEVER
-    var lastIceActivityTimestamp: Instant = NEVER
+    var lastRtpPacketReceivedTimestamp: Instant by vetoable(NEVER) { _, oldValue, newValue ->
+        newValue.isAfter(oldValue)
+    }
+    var lastRtpPacketSentTimestamp: Instant by vetoable(NEVER) { _, oldValue, newValue ->
+        newValue.isAfter(oldValue)
+    }
+    var lastIceActivityTimestamp: Instant by vetoable(NEVER) { _, oldValue, newValue ->
+        newValue.isAfter(oldValue)
+    }
 
     val lastOverallRtpActivity: Instant
         get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp)

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
@@ -19,23 +19,35 @@ package org.jitsi.nlj.stats
 import org.jitsi.nlj.util.NEVER
 import org.jitsi.nlj.util.latest
 import java.time.Instant
-import kotlin.math.max
 
 class PacketIOActivity {
     var lastRtpPacketReceivedTimestamp: Instant = NEVER
     var lastRtpPacketSentTimestamp: Instant = NEVER
+    var lastIceActivityTimestamp: Instant = NEVER
 
     val lastOverallRtpActivity: Instant
         get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp)
 
+    val latestOverallActivity: Instant
+        get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp, lastIceActivityTimestamp)
+
+    // Deprecated
+
     @Deprecated(replaceWith = ReplaceWith("lastRtpPacketReceivedTimestamp"), message = "Deprecated")
-    var lastPacketReceivedTimestampMs: Long = 0
+    var lastPacketReceivedTimestampMs: Long
+        set(value) {
+            lastRtpPacketReceivedTimestamp = Instant.ofEpochMilli(value)
+        }
+        get() = lastRtpPacketSentTimestamp.toEpochMilli()
+
     @Deprecated(replaceWith = ReplaceWith("lastRtpPacketSentTimestamp"), message = "Deprecated")
-    var lastPacketSentTimestampMs: Long = 0
+    var lastPacketSentTimestampMs: Long
+        set(value) {
+            lastRtpPacketSentTimestamp = Instant.ofEpochMilli(value)
+        }
+        get() = lastRtpPacketSentTimestamp.toEpochMilli()
 
     @Deprecated(replaceWith = ReplaceWith("lastOverallRtpPactivity"), message = "Deprecated")
     val lastOverallActivityTimestampMs: Long
-        get() {
-            return max(lastPacketReceivedTimestampMs, lastPacketSentTimestampMs)
-        }
+        get() = lastOverallRtpActivity.toEpochMilli()
 }

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
@@ -16,12 +16,24 @@
 
 package org.jitsi.nlj.stats
 
+import org.jitsi.nlj.util.NEVER
+import org.jitsi.nlj.util.latest
+import java.time.Instant
 import kotlin.math.max
 
 class PacketIOActivity {
+    var lastRtpPacketReceivedTimestamp: Instant = NEVER
+    var lastRtpPacketSentTimestamp: Instant = NEVER
+
+    val lastOverallRtpActivity: Instant
+        get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp)
+
+    @Deprecated(replaceWith = ReplaceWith("lastRtpPacketReceivedTimestamp"), message = "Deprecated")
     var lastPacketReceivedTimestampMs: Long = 0
+    @Deprecated(replaceWith = ReplaceWith("lastRtpPacketSentTimestamp"), message = "Deprecated")
     var lastPacketSentTimestampMs: Long = 0
 
+    @Deprecated(replaceWith = ReplaceWith("lastOverallRtpPactivity"), message = "Deprecated")
     val lastOverallActivityTimestampMs: Long
         get() {
             return max(lastPacketReceivedTimestampMs, lastPacketSentTimestampMs)

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
@@ -18,17 +18,18 @@ package org.jitsi.nlj.stats
 
 import org.jitsi.nlj.util.NEVER
 import org.jitsi.nlj.util.latest
+import org.jitsi.nlj.util.threadSafeVetoable
 import java.time.Instant
-import kotlin.properties.Delegates.vetoable
 
+@Suppress("unused")
 class PacketIOActivity {
-    var lastRtpPacketReceivedTimestamp: Instant by vetoable(NEVER) { _, oldValue, newValue ->
+    var lastRtpPacketReceivedTimestamp: Instant by threadSafeVetoable(NEVER) { _, oldValue, newValue ->
         newValue.isAfter(oldValue)
     }
-    var lastRtpPacketSentTimestamp: Instant by vetoable(NEVER) { _, oldValue, newValue ->
+    var lastRtpPacketSentTimestamp: Instant by threadSafeVetoable(NEVER) { _, oldValue, newValue ->
         newValue.isAfter(oldValue)
     }
-    var lastIceActivityTimestamp: Instant by vetoable(NEVER) { _, oldValue, newValue ->
+    var lastIceActivityTimestamp: Instant by threadSafeVetoable(NEVER) { _, oldValue, newValue ->
         newValue.isAfter(oldValue)
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/util/InstantUtils.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/InstantUtils.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.util
+
+import java.time.Instant
+
+fun latest(vararg instants: Instant): Instant =
+    instants.reduce { a, b -> maxOf(a, b) }

--- a/src/main/kotlin/org/jitsi/nlj/util/ThreadSafeVetoable.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ThreadSafeVetoable.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.util
+
+import kotlin.properties.ObservableProperty
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+public inline fun <T> threadSafeVetoable(initialValue: T, crossinline onChange: (property: KProperty<*>, oldValue: T, newValue: T) -> Boolean):
+    ReadWriteProperty<Any?, T> = object : ObservableProperty<T>(initialValue) {
+        private val lock = Any()
+
+        override fun beforeChange(property: KProperty<*>, oldValue: T, newValue: T): Boolean =
+            onChange(property, oldValue, newValue)
+
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+            synchronized(lock) {
+                super.setValue(thisRef, property, value)
+            }
+        }
+    }

--- a/src/main/kotlin/org/jitsi/nlj/util/ThreadSafeVetoable.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ThreadSafeVetoable.kt
@@ -20,6 +20,9 @@ import kotlin.properties.ObservableProperty
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
+/**
+ * Same as [kotlin.properties.Delegates.vetoable], but thread safe
+ */
 public inline fun <T> threadSafeVetoable(initialValue: T, crossinline onChange: (property: KProperty<*>, oldValue: T, newValue: T) -> Boolean):
     ReadWriteProperty<Any?, T> = object : ObservableProperty<T>(initialValue) {
         private val lock = Any()

--- a/src/test/kotlin/org/jitsi/nlj/stats/PacketIOActivityTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/stats/PacketIOActivityTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.stats
+
+import com.nhaarman.mockitokotlin2.spy
+import io.kotlintest.IsolationMode
+import io.kotlintest.minutes
+import io.kotlintest.seconds
+import io.kotlintest.specs.ShouldSpec
+import io.kotlintest.shouldBe
+import org.jitsi.nlj.test_utils.FakeClock
+
+class PacketIOActivityTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    private val packetIoActivity = PacketIOActivity()
+    private val clock: FakeClock = spy()
+
+    init {
+        "Last packet time values" {
+            clock.elapse(1.minutes)
+            val oldTime = clock.instant()
+            clock.elapse(1.minutes)
+            val newTime = clock.instant()
+            packetIoActivity.lastRtpPacketSentTimestamp = newTime
+            packetIoActivity.lastRtpPacketReceivedTimestamp = newTime
+            packetIoActivity.lastIceActivityTimestamp = newTime
+            "when setting an older time" {
+                packetIoActivity.lastRtpPacketSentTimestamp = oldTime
+                packetIoActivity.lastRtpPacketReceivedTimestamp = oldTime
+                packetIoActivity.lastIceActivityTimestamp = oldTime
+                should("not allow going backwards") {
+                    packetIoActivity.lastRtpPacketSentTimestamp shouldBe newTime
+                    packetIoActivity.lastRtpPacketReceivedTimestamp shouldBe newTime
+                    packetIoActivity.lastIceActivityTimestamp shouldBe newTime
+                }
+            }
+        }
+        "lastOverallRtpActivity" {
+            should("only reflect RTP packet time values") {
+                clock.elapse(30.seconds)
+                val rtpSentTime = clock.instant()
+                clock.elapse(5.seconds)
+                val rtpReceivedTime = clock.instant()
+                clock.elapse(10.seconds)
+                val iceTime = clock.instant()
+                packetIoActivity.lastRtpPacketSentTimestamp = rtpSentTime
+                packetIoActivity.lastRtpPacketReceivedTimestamp = rtpReceivedTime
+                packetIoActivity.lastIceActivityTimestamp = iceTime
+                packetIoActivity.lastOverallRtpActivity shouldBe rtpReceivedTime
+            }
+        }
+        "lastOverallActivity" {
+            should("only reflect all packet time values") {
+                clock.elapse(30.seconds)
+                val rtpSentTime = clock.instant()
+                clock.elapse(10.seconds)
+                val iceTime = clock.instant()
+                clock.elapse(5.seconds)
+                val rtpReceivedTime = clock.instant()
+                packetIoActivity.lastRtpPacketSentTimestamp = rtpSentTime
+                packetIoActivity.lastRtpPacketReceivedTimestamp = rtpReceivedTime
+                packetIoActivity.lastIceActivityTimestamp = iceTime
+                packetIoActivity.lastOverallRtpActivity shouldBe rtpReceivedTime
+            }
+        }
+    }
+}


### PR DESCRIPTION
This distinguishes RTP activity from ICE activity, and also uses `Instant` in place of a `Long` number of milliseconds.  Came from discussion [here](https://github.com/jitsi/jitsi-videobridge/pull/970)