### PR TITLE
jitsi-videobridge correct method for endpoint expiration

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
@@ -36,7 +36,7 @@ class PacketIOActivity {
     val lastOverallRtpActivity: Instant
         get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp)
 
-    val lastOverallReceivedActivity: Instant
+    val lastOverallIncomingActivity: Instant
         get() = latest(lastRtpPacketReceivedTimestamp, lastIceActivityTimestamp)
 
     val latestOverallActivity: Instant

--- a/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/PacketIOActivity.kt
@@ -36,6 +36,9 @@ class PacketIOActivity {
     val lastOverallRtpActivity: Instant
         get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp)
 
+    val lastOverallReceivedActivity: Instant
+        get() = latest(lastRtpPacketReceivedTimestamp, lastIceActivityTimestamp)
+
     val latestOverallActivity: Instant
         get() = latest(lastRtpPacketReceivedTimestamp, lastRtpPacketSentTimestamp, lastIceActivityTimestamp)
 }


### PR DESCRIPTION
in org.jitsi.videobridge.Endpoint.shouldExpire method it's not correctly to calculate endpoint activity with lastRtpPacketSentTimestamp time, because this time is set to one endpoint based on another endpoint activity(lastRtpPacketReceivedTimestamp). In this case first endpoint is never be expired if you have at least one active(sending) endpoint.