### PR TITLE
Allow parsing a Bandwidth from a String

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -116,11 +116,12 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
         fun fromString(str: String): Bandwidth {
             val (digits, notDigits) = str.partition { it.isDigit() }
             val amount = digits.toInt()
-            return when (notDigits) {
+            val unit = notDigits.trim()
+            return when (unit) {
                 "bps" -> amount.bps
                 "kbps" -> amount.kbps
                 "mbps" -> amount.mbps
-                else -> throw IllegalArgumentException("Unrecognized unit $notDigits")
+                else -> throw IllegalArgumentException("Unrecognized unit $unit")
             }
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -111,6 +111,19 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
     }
 
     override fun hashCode(): Int = bps.hashCode()
+
+    companion object {
+        fun fromString(str: String): Bandwidth {
+            val (digits, notDigits) = str.partition { it.isDigit() }
+            val amount = digits.toInt()
+            return when (notDigits) {
+                "bps" -> amount.bps
+                "kbps" -> amount.kbps
+                "mbps" -> amount.mbps
+                else -> throw IllegalArgumentException("Unrecognized unit $notDigits")
+            }
+        }
+    }
 }
 
 val Int.bps: Bandwidth

--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -116,7 +116,7 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
         fun fromString(str: String): Bandwidth {
             val (digits, notDigits) = str.partition { it.isDigit() }
             val amount = digits.toInt()
-            val unit = notDigits.trim()
+            val unit = notDigits.trim().toLowerCase()
             return when (unit) {
                 "bps" -> amount.bps
                 "kbps" -> amount.kbps

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -64,6 +64,7 @@ class BandwidthTest : ShouldSpec() {
                 Bandwidth.fromString("10mbps") shouldBe 10.mbps
                 Bandwidth.fromString("10bps") shouldBe 10.bps
                 Bandwidth.fromString("10kbps") shouldBe 10.kbps
+                Bandwidth.fromString("10 kbps") shouldBe 10.kbps
             }
             shouldThrow<IllegalArgumentException> { Bandwidth.fromString("10foos") }
         }

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -65,6 +65,7 @@ class BandwidthTest : ShouldSpec() {
                 Bandwidth.fromString("10bps") shouldBe 10.bps
                 Bandwidth.fromString("10kbps") shouldBe 10.kbps
                 Bandwidth.fromString("10 kbps") shouldBe 10.kbps
+                Bandwidth.fromString("10 KbPs") shouldBe 10.kbps
             }
             should("throw on an invalid unit") {
                 shouldThrow<IllegalArgumentException> { Bandwidth.fromString("10foos") }

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -66,7 +66,9 @@ class BandwidthTest : ShouldSpec() {
                 Bandwidth.fromString("10kbps") shouldBe 10.kbps
                 Bandwidth.fromString("10 kbps") shouldBe 10.kbps
             }
-            shouldThrow<IllegalArgumentException> { Bandwidth.fromString("10foos") }
+            should("throw on an invalid unit") {
+                shouldThrow<IllegalArgumentException> { Bandwidth.fromString("10foos") }
+            }
         }
     }
 }

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -20,6 +20,7 @@ import io.kotlintest.matchers.beGreaterThan
 import io.kotlintest.seconds
 import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
 import io.kotlintest.specs.ShouldSpec
 
 class BandwidthTest : ShouldSpec() {
@@ -57,6 +58,14 @@ class BandwidthTest : ShouldSpec() {
             should("work correctly") {
                 1.megabytes.per(1.seconds) shouldBe 8.mbps
             }
+        }
+        "creation from a string" {
+            should("work correctly") {
+                Bandwidth.fromString("10mbps") shouldBe 10.mbps
+                Bandwidth.fromString("10bps") shouldBe 10.bps
+                Bandwidth.fromString("10kbps") shouldBe 10.kbps
+            }
+            shouldThrow<IllegalArgumentException> { Bandwidth.fromString("10foos") }
         }
     }
 }


### PR DESCRIPTION
We can use this to parse bandwidth strings into a `Bandwidth` in a config file (we have one in `SendSideBandwidthEstimation` config