### PR TITLE
Fix bandwidth plusAssign.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -24,8 +24,7 @@ import java.time.Duration
  * of bits per second.
  */
 class Bandwidth(bps: Double) : Comparable<Bandwidth> {
-    var bps: Double = bps
-        private set
+    val bps: Double = bps
 
     val kbps: Double = bps / 1000
     val mbps: Double = bps / (1000 * 1000)

--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -33,16 +33,8 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
     operator fun minus(other: Bandwidth): Bandwidth =
         Bandwidth(bps - other.bps)
 
-    operator fun minusAssign(other: Bandwidth) {
-        bps -= other.bps
-    }
-
     operator fun plus(other: Bandwidth): Bandwidth =
         Bandwidth(bps + other.bps)
-
-    operator fun plusAssign(other: Bandwidth) {
-        bps += other.bps
-    }
 
     /**
      * For multiplication, we support multiplying against
@@ -56,16 +48,8 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
     operator fun times(other: Double): Bandwidth =
         Bandwidth(bps * other)
 
-    operator fun timesAssign(other: Double) {
-        bps *= other
-    }
-
     operator fun times(other: Int): Bandwidth =
         Bandwidth(bps * other)
-
-    operator fun timesAssign(other: Int) {
-        bps *= other
-    }
 
     /**
      * For division, we support both dividing by
@@ -75,16 +59,8 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
     operator fun div(other: Double): Bandwidth =
         Bandwidth(bps / other)
 
-    operator fun divAssign(other: Double) {
-        bps /= other
-    }
-
     operator fun div(other: Int): Bandwidth =
         Bandwidth(bps / other)
-
-    operator fun divAssign(other: Int) {
-        bps /= other
-    }
 
     operator fun div(other: Bandwidth): Double =
         bps / other.bps

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -41,6 +41,33 @@ class BandwidthTest : ShouldSpec() {
                 1.mbps / 4.mbps shouldBe 0.25
             }
         }
+        "operation-assign operations on bandwidths" {
+            should("work correctly") {
+                var b = 1.mbps
+                b += 0.5.mbps
+                b shouldBe 1.5.mbps
+                b.kbps shouldBe 1500.0
+                b.bps shouldBe 1_500_000.0
+
+                b = 1.mbps
+                b -= 0.5.mbps
+                b shouldBe 0.5.mbps
+                b.kbps shouldBe 500.0
+                b.bps shouldBe 500_000.0
+
+                b = 1.mbps
+                b *= 2.0
+                b shouldBe 2.0.mbps
+                b.kbps shouldBe 2_000.0
+                b.bps shouldBe 2_000_000.0
+
+                b = 1.mbps
+                b /= 2.0
+                b shouldBe 0.5.mbps
+                b.kbps shouldBe 500.0
+                b.bps shouldBe 500_000.0
+            }
+        }
         "printing bandwidths" {
             should("print as the most appropriate unit") {
                 2_500_000.bps.toString() shouldBe "2.5 mbps"


### PR DESCRIPTION
With both `plus` and `plusAssign` the compiler couldn't disambiguate and `+=` could not be used. The `plusAssign` implementation changed `bps`, but since `kpbs` and `mbps` are derived in the constructor they were left with stale values. So I just removed them and `+=` appears to work as expected.
