### PR TITLE
Make FakeClock instantiable without spy().

### DIFF
--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -35,6 +35,7 @@ import org.jitsi.rtp.UnparsedPacket
 class DtlsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
     private val debugEnabled = true
+    private val pcapEnabled = false
     private val logger = StdoutLogger()
 
     fun debug(s: String) {
@@ -58,19 +59,23 @@ class DtlsTest : ShouldSpec() {
         val clientSender = ProtocolSender(dtlsClient)
         val clientReceiver = ProtocolReceiver(dtlsClient)
 
-        val pcapWriter = PcapWriter(logger, "/tmp/dtls-test.pcap")
+        val pcapWriter = PcapWriter(logger, if (pcapEnabled) "/tmp/dtls-test.pcap" else "/dev/null")
 
         // The server and client senders are connected directly to their
         // peer's receiver
         serverSender.attach(object : ConsumerNode("server network") {
             override fun consume(packetInfo: PacketInfo) {
-                pcapWriter.processPacket(packetInfo)
+                if (pcapEnabled) {
+                    pcapWriter.processPacket(packetInfo)
+                }
                 clientReceiver.processPacket(packetInfo)
             }
         })
         clientSender.attach(object : ConsumerNode("client network") {
             override fun consume(packetInfo: PacketInfo) {
-                pcapWriter.processPacket(packetInfo)
+                if (pcapEnabled) {
+                    pcapWriter.processPacket(packetInfo)
+                }
                 serverReceiver.processPacket(packetInfo)
             }
         })

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -59,23 +59,19 @@ class DtlsTest : ShouldSpec() {
         val clientSender = ProtocolSender(dtlsClient)
         val clientReceiver = ProtocolReceiver(dtlsClient)
 
-        val pcapWriter = PcapWriter(logger, if (pcapEnabled) "/tmp/dtls-test.pcap" else "/dev/null")
+        val pcapWriter = if (pcapEnabled) PcapWriter(logger, "/tmp/dtls-test.pcap") else null
 
         // The server and client senders are connected directly to their
         // peer's receiver
         serverSender.attach(object : ConsumerNode("server network") {
             override fun consume(packetInfo: PacketInfo) {
-                if (pcapEnabled) {
-                    pcapWriter.processPacket(packetInfo)
-                }
+                pcapWriter?.processPacket(packetInfo)
                 clientReceiver.processPacket(packetInfo)
             }
         })
         clientSender.attach(object : ConsumerNode("client network") {
             override fun consume(packetInfo: PacketInfo) {
-                if (pcapEnabled) {
-                    pcapWriter.processPacket(packetInfo)
-                }
+                pcapWriter?.processPacket(packetInfo)
                 serverReceiver.processPacket(packetInfo)
             }
         })

--- a/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
@@ -16,7 +16,6 @@
 
 package org.jitsi.nlj.rtcp
 
-import com.nhaarman.mockitokotlin2.spy
 import io.kotlintest.IsolationMode
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldHaveSize
@@ -63,7 +62,7 @@ class KeyframeRequesterTest : ShouldSpec() {
         override fun getRemoteSecondarySsrc(primarySsrc: Long, associationType: SsrcAssociationType): Long? = null
     }
     private val logger = StdoutLogger()
-    private val clock: FakeClock = spy()
+    private val clock: FakeClock = FakeClock()
 
     private val keyframeRequester = KeyframeRequester(streamInformationStore, logger, clock)
     private val sentKeyframeRequests = mutableListOf<PacketInfo>()

--- a/src/test/kotlin/org/jitsi/nlj/stats/EndpointConnectionStatsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/stats/EndpointConnectionStatsTest.kt
@@ -18,7 +18,6 @@ package org.jitsi.nlj.stats
 
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
 import io.kotlintest.IsolationMode
 import io.kotlintest.matchers.doubles.plusOrMinus
 import io.kotlintest.milliseconds
@@ -35,7 +34,7 @@ import org.jitsi.rtp.rtcp.RtcpSrPacket
 class EndpointConnectionStatsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val clock: FakeClock = spy()
+    private val clock: FakeClock = FakeClock()
 
     private var mostRecentPublishedRtt: Double = -1.0
     private var numRttUpdates: Int = 0

--- a/src/test/kotlin/org/jitsi/nlj/stats/PacketIOActivityTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/stats/PacketIOActivityTest.kt
@@ -16,7 +16,6 @@
 
 package org.jitsi.nlj.stats
 
-import com.nhaarman.mockitokotlin2.spy
 import io.kotlintest.IsolationMode
 import io.kotlintest.minutes
 import io.kotlintest.seconds
@@ -28,7 +27,7 @@ class PacketIOActivityTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     private val packetIoActivity = PacketIOActivity()
-    private val clock: FakeClock = spy()
+    private val clock: FakeClock = FakeClock()
 
     init {
         "Last packet time values" {

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeClock.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeClock.kt
@@ -19,12 +19,14 @@ package org.jitsi.nlj.test_utils
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
 
 /**
  * A fake [Clock] whose time is advanced manually
  */
-internal abstract class FakeClock(
-    private val debug: Boolean = false
+internal class FakeClock(
+    private val debug: Boolean = false,
+    private val zone_: ZoneId = ZoneId.systemDefault()
 ) : Clock() {
     private var now = Instant.ofEpochMilli(0)
 
@@ -46,5 +48,15 @@ internal abstract class FakeClock(
     fun setTime(instant: Instant) {
         log("clock setting time to $instant")
         now = instant
+    }
+
+    override fun getZone(): ZoneId {
+        return zone_
+    }
+
+    override fun withZone(zone: ZoneId?): Clock {
+        if (zone_ == zone)
+            return this
+        return FakeClock(zone_ = zone!!)
     }
 }

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeExecutorService.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeExecutorService.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.Future
 
 internal abstract class FakeExecutorService : ExecutorService {
     private var jobs = JobsTimeline()
-    val clock: FakeClock = stubOnlySpy()
+    val clock: FakeClock = FakeClock()
 
     override fun execute(command: Runnable) {
         jobs.add(Job(command, clock.instant()))

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeScheduledExecutorService.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeScheduledExecutorService.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
  */
 internal abstract class FakeScheduledExecutorService : ScheduledExecutorService {
     private var jobs = JobsTimeline()
-    val clock: FakeClock = stubOnlySpy()
+    val clock: FakeClock = FakeClock()
 
     override fun scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit): ScheduledFuture<*> {
         val future: ScheduledFuture<Unit> = mock(stubOnly = true)

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
@@ -4,7 +4,6 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doNothing
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
 import io.kotlintest.IsolationMode
 import io.kotlintest.Spec
@@ -24,7 +23,7 @@ import org.jitsi.rtp.rtp.header_extensions.TccHeaderExtension
 class TccGeneratorNodeTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val clock: FakeClock = spy()
+    private val clock: FakeClock = FakeClock()
     private val tccPackets = mutableListOf<RtcpPacket>()
     private val onTccReady = { tccPacket: RtcpPacket -> tccPackets.add(tccPacket); Unit }
     private val streamInformationStore: StreamInformationStore = mock()


### PR DESCRIPTION
This removes Mockito overhead from its method calls, speeding up BandwidthEstimationTest substantially.