### PR TITLE
Remember previously-received TCC reports.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -262,6 +262,7 @@ class Transceiver(
             addJson("Bandwidth Estimation", bandwidthEstimator.getStats(clock.instant()).toJson())
             addBlock(rtpReceiver.getNodeStats())
             addBlock(rtpSender.getNodeStats())
+            addJson("transportCcEngine", transportCcEngine.getStatistics().toJson())
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -201,6 +201,8 @@ class TransportCcEngine(
                 /* Very old seq? Something odd is happening with whatever is
                  * generating tccSeqNum values.
                  */
+                logger.warn("Not inserting very old TCC seq num $seq ($tccSeqNum), latest is " +
+                    "${sentPacketDetails.firstKey()}")
                 return
             }
             sentPacketDetails.put(seq, PacketDetail(length, now))

--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -202,7 +202,7 @@ class TransportCcEngine(
                  * generating tccSeqNum values.
                  */
                 logger.warn("Not inserting very old TCC seq num $seq ($tccSeqNum), latest is " +
-                    "${sentPacketDetails.firstKey()}")
+                    "${sentPacketDetails.lastKey()}")
                 return
             }
             sentPacketDetails.put(seq, PacketDetail(length, now))

--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -197,8 +197,7 @@ class TransportCcEngine(
             while (hasNext()) {
                 val key = next()
                 if (isOlderSequenceNumberThan(key, threshold)) {
-                    var details = sentPacketDetails.get(key)
-                    if (details?.state == PacketDetailState.unreported) {
+                    if (sentPacketDetails.get(key)?.state == PacketDetailState.unreported) {
                         numPacketsUnreported.getAndIncrement()
                     }
                     remove()

--- a/src/test/kotlin/org/jitsi/nlj/rtp/TransportCcEngineTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/TransportCcEngineTest.kt
@@ -1,0 +1,92 @@
+package org.jitsi.nlj.rtp
+
+import com.nhaarman.mockitokotlin2.mock
+import io.kotlintest.IsolationMode
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.ShouldSpec
+import org.jitsi.nlj.resources.logging.StdoutLogger
+import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
+import org.jitsi.nlj.test_utils.FakeClock
+import org.jitsi.nlj.util.bytes
+import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacketBuilder
+import java.util.logging.Level
+
+class TransportCcEngineTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    private val bandwidthEstimator: BandwidthEstimator = mock()
+    private val clock: FakeClock = FakeClock()
+    private val logger = StdoutLogger(_level = Level.INFO)
+
+    private val transportCcEngine = TransportCcEngine(bandwidthEstimator, logger, clock)
+
+    init {
+        "foo" {
+            transportCcEngine.mediaPacketSent(4, 1300.bytes)
+            val tccPacket = with(RtcpFbTccPacketBuilder(mediaSourceSsrc = 123, feedbackPacketSeqNum = 0)) {
+                SetBase(1, 100)
+                AddReceivedPacket(1, 100)
+                AddReceivedPacket(2, 110)
+                AddReceivedPacket(3, 120)
+                AddReceivedPacket(4, 130)
+                build()
+            }
+
+            transportCcEngine.rtcpPacketReceived(tccPacket, clock.instant().toEpochMilli())
+
+            var stats = transportCcEngine.getStatistics()
+
+            stats.numMissingPacketReports shouldBe 3
+            stats.numDuplicateReports shouldBe 0
+            stats.numPacketsReportedAfterLost shouldBe 0
+            stats.numPacketsUnreported shouldBe 0
+
+            transportCcEngine.mediaPacketSent(5, 1300.bytes)
+            transportCcEngine.mediaPacketSent(6, 1300.bytes)
+
+            val tccPacket2 = with(RtcpFbTccPacketBuilder(mediaSourceSsrc = 123, feedbackPacketSeqNum = 1)) {
+                SetBase(4, 130)
+                AddReceivedPacket(4, 130)
+                AddReceivedPacket(6, 150)
+                build()
+            }
+
+            transportCcEngine.rtcpPacketReceived(tccPacket2, clock.instant().toEpochMilli())
+
+            stats = transportCcEngine.getStatistics()
+
+            stats.numMissingPacketReports shouldBe 3
+            stats.numDuplicateReports shouldBe 1
+            stats.numPacketsReportedAfterLost shouldBe 0
+            stats.numPacketsUnreported shouldBe 0
+
+            val tccPacket3 = with(RtcpFbTccPacketBuilder(mediaSourceSsrc = 123, feedbackPacketSeqNum = 3)) {
+                SetBase(5, 140)
+                AddReceivedPacket(5, 140)
+                AddReceivedPacket(6, 150)
+                build()
+            }
+
+            transportCcEngine.rtcpPacketReceived(tccPacket3, clock.instant().toEpochMilli())
+
+            stats = transportCcEngine.getStatistics()
+
+            stats.numMissingPacketReports shouldBe 3
+            stats.numDuplicateReports shouldBe 2
+            stats.numPacketsReportedAfterLost shouldBe 1
+            stats.numPacketsUnreported shouldBe 0
+
+            transportCcEngine.mediaPacketSent(7, 1300.bytes)
+            /* Force the report of sequence 7 to roll off the packet history */
+            transportCcEngine.mediaPacketSent(1008, 1300.bytes)
+            transportCcEngine.mediaPacketSent(1009, 1300.bytes)
+
+            stats = transportCcEngine.getStatistics()
+
+            stats.numMissingPacketReports shouldBe 3
+            stats.numDuplicateReports shouldBe 2
+            stats.numPacketsReportedAfterLost shouldBe 1
+            stats.numPacketsUnreported shouldBe 1
+        }
+    }
+}


### PR DESCRIPTION
Reduces warnings about missing sequences.