### PR TITLE
Arraycache use external time

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -251,7 +251,7 @@ class TransportCcEngine(
 
         fun insert(seq: Int, packetDetail: PacketDetail): Boolean {
             val index = rfc3711IndexTracker.update(seq)
-            return super.insertItem(packetDetail, index)
+            return super.insertItem(packetDetail, index, packetDetail.packetSendTime.toEpochMilli())
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -77,7 +77,7 @@ class TransportCcEngine(
      * Holds a key value pair of the packet sequence number and an object made
      * up of the packet send time and the packet size.
      */
-    private val sentPacketDetails = PacketDetailTracker()
+    private val sentPacketDetails = PacketDetailTracker(clock)
 
     private val missingPacketDetailSeqNums = mutableListOf<Int>()
 
@@ -226,10 +226,12 @@ class TransportCcEngine(
         }
     }
 
-    private inner class PacketDetailTracker : ArrayCache<PacketDetail>(
+    private inner class PacketDetailTracker(clock: Clock) : ArrayCache<PacketDetail>(
         MAX_OUTGOING_PACKETS_HISTORY,
         /* We don't want to clone [PacketDetail] objects that get put in the tracker. */
-        { it }
+        { it },
+        true,
+        clock
     ) {
         override fun discardItem(item: PacketDetail) {
             numPacketsUnreported.getAndIncrement()

--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -230,8 +230,7 @@ class TransportCcEngine(
         MAX_OUTGOING_PACKETS_HISTORY,
         /* We don't want to clone [PacketDetail] objects that get put in the tracker. */
         { it },
-        true,
-        clock
+        clock = clock
     ) {
         override fun discardItem(item: PacketDetail) {
             numPacketsUnreported.getAndIncrement()

--- a/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
@@ -63,16 +63,23 @@ open class ArrayCache<T>(
     /**
      * Inserts an item with a specific index in the cache. Stores a copy.
      */
-    fun insertItem(item: T, index: Int): Boolean =
+    fun insertItem(item: T, index: Int, timeAdded: Long): Boolean =
         if (synchronize) {
             synchronized(syncRoot) {
-                doInsert(item, index)
+                doInsert(item, index, timeAdded)
             }
         } else {
-            doInsert(item, index)
+            doInsert(item, index, timeAdded)
         }
 
-    private fun doInsert(item: T, index: Int): Boolean {
+    /**
+     * Inserts an item with a specific index in the cache, computing time
+     * from [clock]. Stores a copy.
+     */
+    fun insertItem(item: T, index: Int): Boolean =
+        insertItem(item, index, clock.millis())
+
+    private fun doInsert(item: T, index: Int, timeAdded: Long): Boolean {
         val diff = if (head == -1) -1 else index - cache[head].index
         val position = when {
             head == -1 -> {
@@ -95,7 +102,7 @@ open class ArrayCache<T>(
         cache[position].item?.let { discardItem(it) }
         cache[position].item = cloneItem(item)
         cache[position].index = index
-        cache[position].timeAdded = clock.millis()
+        cache[position].timeAdded = timeAdded
         return true
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
@@ -17,10 +17,10 @@
 package org.jitsi.nlj.util
 
 import java.lang.Integer.max
+import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.NodeStatsProducer
-import org.jitsi.utils.TimeProvider
 
 /**
  * Implements a fixed-sized cache based on a pre-filled array. The main use-case is the outgoing RTP packet cache.
@@ -34,7 +34,7 @@ open class ArrayCache<T>(
     /**
      * The function to use to clone items. The cache always saves copies of the items that are inserted.
      */
-    private val timeProvider: TimeProvider = TimeProvider()
+    private val clock: Clock = Clock.systemUTC()
 ) : NodeStatsProducer {
     private val cache: Array<Container> = Array(size) { Container() }
     protected val syncRoot = Any()
@@ -95,7 +95,7 @@ open class ArrayCache<T>(
         cache[position].item?.let { discardItem(it) }
         cache[position].item = cloneItem(item)
         cache[position].index = index
-        cache[position].timeAdded = timeProvider.currentTimeMillis()
+        cache[position].timeAdded = clock.millis()
         return true
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/util/TimeExpiringCache.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/TimeExpiringCache.kt
@@ -16,9 +16,9 @@
 
 package org.jitsi.nlj.util
 
+import java.time.Clock
 import java.time.Duration
 import java.util.TreeMap
-import org.jitsi.utils.TimeProvider
 
 /**
  * A cache which holds an arbitrary [DataType] and stores it, as well
@@ -42,15 +42,15 @@ class TimeExpiringCache<IndexType, DataType>(
      * The maximum amount of elements we'll allow in the cache
      */
     private val maxNumElements: Int,
-    private val timeProvider: TimeProvider = TimeProvider()
+    private val clock: Clock = Clock.systemUTC()
 ) {
     private val cache: TreeMap<IndexType, Container<DataType>> = TreeMap()
 
     fun insert(index: IndexType, data: DataType) {
-        val container = Container(data, timeProvider.currentTimeMillis())
+        val container = Container(data, clock.millis())
         synchronized(cache) {
             cache[index] = container
-            clean(timeProvider.currentTimeMillis() - dataTimeout.toMillis())
+            clean(clock.millis() - dataTimeout.toMillis())
         }
     }
 


### PR DESCRIPTION
Option 1 for eliminating redundant calculation of time in TransportCcEngine.

Option 2 is https://github.com/jitsi/jitsi-media-transform/pull/174.

I'm not crazy about either of these approaches -- comments welcome.