### PR TITLE
Tweak TCC engine warning logs.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -157,7 +157,7 @@ class TransportCcEngine(
                 if (sentPacketDetails.empty) {
                     "Sent packet details map was empty."
                 } else {
-                    "Latest seqNum was ${sentPacketDetails.lastIndex and 0xFFFF}, size is ${sentPacketDetails.size}."
+                    "Latest seqNum was ${sentPacketDetails.lastSequence}, size is ${sentPacketDetails.size}."
                 })
             missingPacketDetailSeqNums.clear()
         }
@@ -171,7 +171,7 @@ class TransportCcEngine(
              * generating tccSeqNum values.
              */
             logger.warn("Not inserting very old TCC seq num $seq ($tccSeqNum), latest is " +
-                "${sentPacketDetails.lastIndex and 0xFFFF}, size is ${sentPacketDetails.size}")
+                "${sentPacketDetails.lastSequence}, size is ${sentPacketDetails.size}")
             return
         }
     }
@@ -252,6 +252,9 @@ class TransportCcEngine(
             val index = rfc3711IndexTracker.update(seq)
             return super.insertItem(packetDetail, index, packetDetail.packetSendTime.toEpochMilli())
         }
+
+        val lastSequence: Int
+            get() = if (lastIndex == -1) -1 else lastIndex and 0xFFFF
     }
 
     companion object {

--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -157,7 +157,7 @@ class TransportCcEngine(
                 if (sentPacketDetails.empty) {
                     "Sent packet details map was empty."
                 } else {
-                    "Latest seqNum was ${sentPacketDetails.lastIndex}, size is ${sentPacketDetails.size}."
+                    "Latest seqNum was ${sentPacketDetails.lastIndex and 0xFFFF}, size is ${sentPacketDetails.size}."
                 })
             missingPacketDetailSeqNums.clear()
         }
@@ -171,7 +171,7 @@ class TransportCcEngine(
              * generating tccSeqNum values.
              */
             logger.warn("Not inserting very old TCC seq num $seq ($tccSeqNum), latest is " +
-                "${sentPacketDetails.lastIndex}, size is ${sentPacketDetails.size}")
+                "${sentPacketDetails.lastIndex and 0xFFFF}, size is ${sentPacketDetails.size}")
             return
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
@@ -54,7 +54,7 @@ open class ArrayCache<T>(
     val hitRate
         get() = _numHits.get() * 1.0 / max(1, _numHits.get() + _numMisses.get())
 
-    val lastIndex: Int
+    protected val lastIndex: Int
         get() = if (head == -1) -1 else cache[head].index
 
     val empty: Boolean


### PR DESCRIPTION
So they print the latest seqnum logs as a raw seq, not an extended seq.