### PR TITLE
Node cleanup

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -412,9 +412,8 @@ abstract class ConsumerNode(name: String) : StatsKeepingNode(name) {
     protected abstract fun consume(packetInfo: PacketInfo)
 
     override fun doProcessPacket(packetInfo: PacketInfo) {
-        // TODO(before merging): should we call doneProcessing here?
-        //  Before, or after calling consume?
         consume(packetInfo)
+        doneProcessing(packetInfo)
     }
 
     // Consumer nodes shouldn't have children, because they don't forward

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -339,6 +339,20 @@ abstract class TransformerNode(name: String) : StatsKeepingNode(name) {
 }
 
 /**
+ * Unlike a [TransformerNode], [ModifierNode] modifies a packet in-place and never
+ * outright 'fails', meaning it can never return null.
+ */
+abstract class ModifierNode(name: String) : StatsKeepingNode(name) {
+    protected abstract fun modify(packetInfo: PacketInfo): PacketInfo
+
+    override fun doProcessPacket(packetInfo: PacketInfo) {
+        val modifiedPacket = modify(packetInfo)
+        doneProcessing(modifiedPacket)
+        next(modifiedPacket)
+    }
+}
+
+/**
  * A [Node] which drops some of the packets (the ones which are not accepted).
  */
 abstract class FilterNode(name: String) : TransformerNode(name) {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -381,13 +381,14 @@ abstract class ObserverNode(name: String) : TransformerNode(name) {
 /**
  * A node which consumes all packets (i.e. does something with them, but does not forward them to another node).
  */
-abstract class ConsumerNode(name: String) : TransformerNode(name) {
+abstract class ConsumerNode(name: String) : StatsKeepingNode(name) {
 
     protected abstract fun consume(packetInfo: PacketInfo)
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+    override fun doProcessPacket(packetInfo: PacketInfo) {
+        // TODO(before merging): should we call doneProcessing here?
+        //  Before, or after calling consume?
         consume(packetInfo)
-        return null
     }
 
     // Consumer nodes shouldn't have children, because they don't forward

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -245,7 +245,7 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
         }
     }
 
-    protected fun packetDiscarded(packetInfo: PacketInfo) {
+    protected open fun packetDiscarded(packetInfo: PacketInfo) {
         stats.numDiscardedPackets++
         BufferPool.returnBuffer(packetInfo.packet.buffer)
     }
@@ -349,9 +349,14 @@ abstract class TransformerNode(name: String) : StatsKeepingNode(name) {
         val transformedPacket = transform(packetInfo)
         doneProcessing(transformedPacket)
         when (transformedPacket) {
-            null -> packetDiscarded(packetInfo)
+            null -> super.packetDiscarded(packetInfo)
             else -> next(transformedPacket)
         }
+    }
+
+    final override fun packetDiscarded(packetInfo: PacketInfo) {
+        throw Exception("No subclass of TransformerNode should call packetDiscarded, " +
+            "return null from 'transform' instead")
     }
 }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
@@ -33,7 +33,6 @@ open class PacketParser(
             packetInfo
         } catch (e: Exception) {
             logger.warn("Error parsing packet: $e")
-            packetDiscarded(packetInfo)
             null
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -105,7 +105,6 @@ class RtcpTermination(
             packetInfo.packet = it
             packetInfo
         } ?: run {
-            packetDiscarded(packetInfo)
             null
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -67,7 +67,6 @@ class RtxHandler(
         if (rtpPacket.payloadLength - rtpPacket.paddingSize < 2) {
             logger.cdebug { "RTX packet is padding, ignore" }
             numPaddingPacketsReceived++
-            packetDiscarded(packetInfo)
             return null
         }
         val originalSeqNum = RtxPacket.getOriginalSequenceNumber(rtpPacket)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
@@ -42,7 +42,6 @@ class SilenceDiscarder(
                 .rewriteRtp(!packetInfo.shouldDiscard, packet)
 
             return if (packetInfo.shouldDiscard) {
-                packetDiscarded(packetInfo)
                 null
             } else {
                 packetInfo

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -59,6 +59,7 @@ class VideoParser(
             packetInfo.packet = videoRtpPacket
             packetInfo.resetPayloadVerification()
         } ?: run {
+            // TODO(brian): Shouldn't we drop the packet here?
             logger.error("Unrecognized video payload type ${rtpPacket.payloadType}, cannot parse video information")
         }
         return packetInfo

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -45,7 +45,7 @@ class VideoParser(
     // does this packet represent the end of a frame?
     override fun transform(packetInfo: PacketInfo): PacketInfo? {
         val rtpPacket = packetInfo.packetAs<RtpPacket>()
-        streamInformationStore.rtpPayloadTypes[rtpPacket.payloadType.toByte()]?.let { payloadType ->
+        return streamInformationStore.rtpPayloadTypes[rtpPacket.payloadType.toByte()]?.let { payloadType ->
             val videoRtpPacket = when (payloadType) {
                 is Vp8PayloadType -> {
                     val vp8Packet = rtpPacket.toOtherType(::Vp8Packet)
@@ -58,11 +58,11 @@ class VideoParser(
             }
             packetInfo.packet = videoRtpPacket
             packetInfo.resetPayloadVerification()
+            packetInfo
         } ?: run {
-            // TODO(brian): Shouldn't we drop the packet here?
             logger.error("Unrecognized video payload type ${rtpPacket.payloadType}, cannot parse video information")
+            null
         }
-        return packetInfo
     }
 
     private fun findRtpEncodingDesc(packet: VideoRtpPacket): RTPEncodingDesc? {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -20,7 +20,7 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.rtp.codec.vp8.Vp8Packet
 import org.jitsi.nlj.stats.NodeStatsBlock
-import org.jitsi.nlj.transform.node.TransformerNode
+import org.jitsi.nlj.transform.node.ModifierNode
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.createChildLogger
 import org.jitsi.utils.logging2.Logger
@@ -29,16 +29,20 @@ import org.jitsi.utils.logging2.Logger
  * Some [Vp8Packet] fields are not able to be determined by looking at a single VP8 packet (for example the spatial
  * layer index can only be acquired from keyframes).  This class keeps a longer-running 'memory' of the information
  * needed to fill out fields like that in [Vp8Packet]s
+ *
+ * TODO(brian): This class shouldn't really be a [ModifierNode], but since we put it in-line in the video
+ * receive pipeline (as opposed to demuxing based on payload type and routing only known VP8 packets to
+ * it), it's the most appropriate node type for now.
  */
 class Vp8Parser(
     parentLogger: Logger
-) : TransformerNode("Vp8 parser") {
+) : ModifierNode("Vp8 parser") {
     private val logger = parentLogger.createChildLogger(Vp8Parser::class)
     private val ssrcToHeight: MutableMap<Long, Int> = HashMap()
     // Stats
     private var numKeyframes: Int = 0
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+    override fun modify(packetInfo: PacketInfo): PacketInfo {
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket
         if (videoRtpPacket is Vp8Packet) {
             // If this was part of a keyframe, it will have already had it set

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -18,12 +18,14 @@ package org.jitsi.nlj.transform.node.outgoing
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.RtpExtensionType.ABS_SEND_TIME
 import org.jitsi.nlj.stats.NodeStatsBlock
-import org.jitsi.nlj.transform.node.TransformerNode
+import org.jitsi.nlj.transform.node.ModifierNode
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.AbsSendTimeHeaderExtension
 
-class AbsSendTime(streamInformationStore: ReadOnlyStreamInformationStore) : TransformerNode("Absolute send time") {
+class AbsSendTime(
+    streamInformationStore: ReadOnlyStreamInformationStore
+) : ModifierNode("Absolute send time") {
     private var extensionId: Int? = null
 
     init {
@@ -32,7 +34,7 @@ class AbsSendTime(streamInformationStore: ReadOnlyStreamInformationStore) : Tran
         }
     }
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+    override fun modify(packetInfo: PacketInfo): PacketInfo {
         extensionId?.let { absSendTimeExtId ->
             val rtpPacket = packetInfo.packetAs<RtpPacket>()
             val ext = rtpPacket.getHeaderExtension(absSendTimeExtId)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
@@ -18,20 +18,18 @@ package org.jitsi.nlj.transform.node.outgoing
 
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.protocol.ProtocolStack
-import org.jitsi.nlj.transform.node.TransformerNode
+import org.jitsi.nlj.transform.node.ConsumerNode
 
 open class ProtocolSender @JvmOverloads constructor(
     private val stack: ProtocolStack,
     name: String = stack::class.toString()
-) : TransformerNode(name) {
+) : ConsumerNode(name) {
 
     init {
         stack.onOutgoingProtocolData(::next)
     }
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+    override fun consume(packetInfo: PacketInfo) {
         stack.sendApplicationData(packetInfo)
-
-        return null
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
@@ -18,18 +18,27 @@ package org.jitsi.nlj.transform.node.outgoing
 
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.protocol.ProtocolStack
-import org.jitsi.nlj.transform.node.ConsumerNode
+import org.jitsi.nlj.transform.node.TransformerNode
 
+/**
+ * Note that [ProtocolSender] functions as a [TransformerNode]
+ * which always returns null from [transform]: this implies that
+ * all [ProtocolStack] implementations *must* make a copy of
+ * the packet in [ProtocolStack.sendApplicationData] if they need
+ * access to that data after the method is done.
+ */
 open class ProtocolSender @JvmOverloads constructor(
     private val stack: ProtocolStack,
     name: String = stack::class.toString()
-) : ConsumerNode(name) {
+) : TransformerNode(name) {
 
     init {
         stack.onOutgoingProtocolData(::next)
     }
 
-    override fun consume(packetInfo: PacketInfo) {
+    override fun transform(packetInfo: PacketInfo): PacketInfo? {
         stack.sendApplicationData(packetInfo)
+
+        return null
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
@@ -15,24 +15,24 @@
  */
 package org.jitsi.nlj.transform.node.outgoing
 
-import java.util.concurrent.ConcurrentHashMap
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.RtxPayloadType
 import org.jitsi.nlj.rtp.RtxPacket
 import org.jitsi.nlj.rtp.SsrcAssociationType
 import org.jitsi.nlj.stats.NodeStatsBlock
-import org.jitsi.nlj.transform.node.TransformerNode
+import org.jitsi.nlj.transform.node.ModifierNode
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.cdebug
 import org.jitsi.nlj.util.createChildLogger
 import org.jitsi.rtp.extensions.unsigned.toPositiveInt
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.utils.logging2.Logger
+import java.util.concurrent.ConcurrentHashMap
 
 class RetransmissionSender(
     private val streamInformationStore: ReadOnlyStreamInformationStore,
     parentLogger: Logger
-) : TransformerNode("Retransmission sender") {
+) : ModifierNode("Retransmission sender") {
     private val logger = parentLogger.createChildLogger(RetransmissionSender::class)
     /**
      * Maps an original payload type (Int) to its [RtxPayloadType]
@@ -61,7 +61,7 @@ class RetransmissionSender(
     /**
      * Transform an original RTP packet into an RTX-encapsulated form of that packet.
      */
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+    override fun modify(packetInfo: PacketInfo): PacketInfo {
         val rtpPacket = packetInfo.packetAs<RtpPacket>()
         numRetransmissionsRequested++
         val rtxPt = origPtToRtxPayloadType[rtpPacket.payloadType.toPositiveInt()] ?: return retransmitPlain(packetInfo)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -19,7 +19,7 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.RtpExtensionType.TRANSPORT_CC
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.stats.NodeStatsBlock
-import org.jitsi.nlj.transform.node.TransformerNode
+import org.jitsi.nlj.transform.node.ModifierNode
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.bytes
 import org.jitsi.rtp.rtp.RtpPacket
@@ -28,7 +28,7 @@ import org.jitsi.rtp.rtp.header_extensions.TccHeaderExtension
 class TccSeqNumTagger(
     private val transportCcEngine: TransportCcEngine? = null,
     streamInformationStore: ReadOnlyStreamInformationStore
-) : TransformerNode("TCC sequence number tagger") {
+) : ModifierNode("TCC sequence number tagger") {
     private var currTccSeqNum: Int = 1
     private var tccExtensionId: Int? = null
 
@@ -38,7 +38,7 @@ class TccSeqNumTagger(
         }
     }
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+    override fun modify(packetInfo: PacketInfo): PacketInfo {
         tccExtensionId?.let { tccExtId ->
             val rtpPacket = packetInfo.packetAs<RtpPacket>()
             val ext = rtpPacket.getHeaderExtension(tccExtId)


### PR DESCRIPTION
While doing some Octo work I noticed that when `RtpParser` fails to parse a packet the packet is not properly discarded (buffer put back in the pool, stat tracked).  I found a couple other instances of this as well so tweaked the packet hierarchy such that now all descendants of `TransformerNode` are ones which truly mean to discard the packet when they return null.

I had a couple questions in here I want to discuss before merging:
1. When, if at all, to call `doneProcessing` in `ConsumerNode`.  Existing behavior was to call it after `consume`, meaning we include all the time spent there.  Typing this now it seems reasonable to keep this behavior, but I hesitated earlier when implementing. Any thoughts?
2. We still forward a packet if `VideoParser` fails, but I can't think of a good reason why we'd do this.  Thoughts on returning null in that case?
3. I'm open to naming suggestions for `ModifierNode` :)