### PR TITLE
Go through child node

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -132,6 +132,8 @@ class RtpReceiverImpl @JvmOverloads constructor(
             // should be returned.
             packetHandler?.processPacket(packetInfo) ?: packetDiscarded(packetInfo)
         }
+
+        override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
     }
 
     init {

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -134,6 +134,8 @@ class RtpReceiverImpl @JvmOverloads constructor(
         }
 
         override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 
     init {

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -104,6 +104,8 @@ class RtpSenderImpl(
             // should be returned.
             outgoingPacketHandler?.processPacket(packetInfo) ?: packetDiscarded(packetInfo)
         }
+
+        override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
     }
 
     init {

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -106,6 +106,8 @@ class RtpSenderImpl(
         }
 
         override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+        override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 
     init {

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -204,6 +204,8 @@ class KeyframeRequester @JvmOverloads constructor(
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
+
     companion object {
         private val DEFAULT_WAIT_INTERVAL = Duration.ofMillis(100)
     }

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -202,6 +202,8 @@ class KeyframeRequester @JvmOverloads constructor(
         waitInterval = Duration.ofMillis(min(DEFAULT_WAIT_INTERVAL.toMillis(), newRtt.toLong() + 10))
     }
 
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
     companion object {
         private val DEFAULT_WAIT_INTERVAL = Duration.ofMillis(100)
     }

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpParsers.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpParsers.kt
@@ -30,10 +30,14 @@ class CompoundRtcpParser(parentLogger: Logger) : PacketParser("Compound RTCP par
 }) {
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }
 
 class SingleRtcpParser(parentLogger: Logger) : PacketParser("Single RTCP parser", parentLogger, {
     RtcpPacket.parse(it.buffer, it.offset, it.length) }) {
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpParsers.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpParsers.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.rtcp
 
+import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.PacketParser
 import org.jitsi.rtp.rtcp.CompoundRtcpPacket
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -26,7 +27,13 @@ class CompoundRtcpParser(parentLogger: Logger) : PacketParser("Compound RTCP par
         // Force packets to be evaluated to trigger any parsing errors
         compoundPacket.packets
     }
-})
+}) {
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+}
 
 class SingleRtcpParser(parentLogger: Logger) : PacketParser("Single RTCP parser", parentLogger, {
-    RtcpPacket.parse(it.buffer, it.offset, it.length) })
+    RtcpPacket.parse(it.buffer, it.offset, it.length) }) {
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+}

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpSrUpdater.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpSrUpdater.kt
@@ -39,4 +39,6 @@ class RtcpSrUpdater(
 
         return packetInfo
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpSrUpdater.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpSrUpdater.kt
@@ -41,4 +41,6 @@ class RtcpSrUpdater(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
@@ -59,6 +59,8 @@ class PipelineBuilder {
             override fun transform(packetInfo: PacketInfo): PacketInfo? {
                 return packetHandler.invoke(packetInfo)
             }
+
+            override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
         }
         addNode(node)
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
@@ -61,6 +61,8 @@ class PipelineBuilder {
             }
 
             override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
         }
         addNode(node)
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -255,7 +255,7 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
         }
     }
 
-    protected open fun packetDiscarded(packetInfo: PacketInfo) {
+    protected fun packetDiscarded(packetInfo: PacketInfo) {
         stats.numDiscardedPackets++
         BufferPool.returnBuffer(packetInfo.packet.buffer)
     }
@@ -362,11 +362,6 @@ abstract class TransformerNode(name: String) : StatsKeepingNode(name) {
             null -> super.packetDiscarded(packetInfo)
             else -> next(transformedPacket)
         }
-    }
-
-    final override fun packetDiscarded(packetInfo: PacketInfo) {
-        throw Exception("No subclass of TransformerNode should call packetDiscarded, " +
-            "return null from 'transform' instead")
     }
 }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -256,9 +256,17 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
     }
 
     protected fun packetDiscarded(packetInfo: PacketInfo) {
+        // stats.numDiscardedPackets++
+        // BufferPool.returnBuffer(packetInfo.packet.buffer)
+        detailedPacketDiscarded(packetInfo)
+    }
+
+    protected fun packetDiscardedFromChild(packetInfo: PacketInfo) {
         stats.numDiscardedPackets++
         BufferPool.returnBuffer(packetInfo.packet.buffer)
     }
+
+    protected abstract fun detailedPacketDiscarded(packetInfo: PacketInfo)
 
     override fun stop() {
         if (stopped) {
@@ -522,6 +530,8 @@ class ExclusivePathDemuxer(name: String) : DemuxerNode(name) {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) {
-        next(packetInfo)
+        nextFromChild(packetInfo)
     }
+
+    override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -103,8 +103,18 @@ sealed class Node(
         if (PLUGINS_ENABLED) {
             plugins.forEach { it.observe(this, packetInfo) }
         }
+        // nextNode?.processPacket(packetInfo)
+        detailedNext(packetInfo)
+    }
+
+    protected fun nextFromChild(packetInfo: PacketInfo) {
+        if (PLUGINS_ENABLED) {
+            plugins.forEach { it.observe(this, packetInfo) }
+        }
         nextNode?.processPacket(packetInfo)
     }
+
+    protected abstract fun detailedNext(packetInfo: PacketInfo)
 
     protected fun next(packetInfos: List<PacketInfo>) {
         packetInfos.forEach { packetInfo ->
@@ -514,5 +524,9 @@ class ExclusivePathDemuxer(name: String) : DemuxerNode(name) {
             }
         }
         packetDiscarded(packetInfo)
+    }
+
+    override fun detailedNext(packetInfo: PacketInfo) {
+        next(packetInfo)
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
@@ -38,4 +38,6 @@ class PacketCacher : ObserverNode("Packet cache") {
             addBlock(packetCache.getNodeStats())
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
@@ -40,4 +40,6 @@ class PacketCacher : ObserverNode("Packet cache") {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLoss.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLoss.kt
@@ -45,6 +45,8 @@ class PacketLoss(private val lossRate: Double) : FilterNode("Packet loss") {
             addRatio("actual_drop_rate", "packetsDropped", "packetsSeen")
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }
 
 class BurstPacketLoss(
@@ -73,4 +75,6 @@ class BurstPacketLoss(
             true
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLoss.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLoss.kt
@@ -47,6 +47,8 @@ class PacketLoss(private val lossRate: Double) : FilterNode("Packet loss") {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }
 
 class BurstPacketLoss(
@@ -77,4 +79,6 @@ class BurstPacketLoss(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
@@ -19,7 +19,7 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.rtp.Packet
 import org.jitsi.utils.logging2.Logger
 
-open class PacketParser(
+abstract class PacketParser(
     name: String,
     parentLogger: Logger,
     private val action: (Packet) -> Packet

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketStreamStatsNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketStreamStatsNode.kt
@@ -39,4 +39,6 @@ class PacketStreamStatsNode(private val packetStreamStats: PacketStreamStats = P
      * different branches of a [Node] tree.
      */
     fun createNewNode() = PacketStreamStatsNode(packetStreamStats)
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketStreamStatsNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketStreamStatsNode.kt
@@ -41,4 +41,6 @@ class PacketStreamStatsNode(private val packetStreamStats: PacketStreamStats = P
     fun createNewNode() = PacketStreamStatsNode(packetStreamStats)
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
@@ -102,4 +102,6 @@ class PcapWriter(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
@@ -100,4 +100,6 @@ class PcapWriter(
             handle.close()
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
@@ -49,4 +49,6 @@ class RtpParser(
         packetInfo.resetPayloadVerification()
         return packetInfo
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
@@ -51,4 +51,6 @@ class RtpParser(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -144,4 +144,6 @@ class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode(name) {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -142,4 +142,6 @@ class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode(name) {
         }
         transformer?.close()
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -65,6 +65,8 @@ class ToggleablePcapWriter(
                     }
                 }
             }
+
+            override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -67,6 +67,8 @@ class ToggleablePcapWriter(
             }
 
             override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/debug/RtpPacketTraceNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/debug/RtpPacketTraceNode.kt
@@ -25,4 +25,6 @@ class RtpPacketTraceNode(val where: String) : ObserverNode("RtpPacketTraceNode@$
         val rtpPacket = packetInfo.packetAs<RtpPacket>()
         println("$where: RTP packet ${rtpPacket.ssrc} ${rtpPacket.sequenceNumber}")
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/debug/RtpPacketTraceNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/debug/RtpPacketTraceNode.kt
@@ -27,4 +27,6 @@ class RtpPacketTraceNode(val where: String) : ObserverNode("RtpPacketTraceNode@$
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -66,4 +66,6 @@ class AudioLevelReader(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -64,4 +64,6 @@ class AudioLevelReader(
             addString("audio_level_ext_id", audioLevelExtId.toString())
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -75,6 +75,8 @@ class IncomingStatisticsTracker(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }
 
 class IncomingStatisticsSnapshot(

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -73,6 +73,8 @@ class IncomingStatisticsTracker(
             }.toMap()
         )
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }
 
 class IncomingStatisticsSnapshot(

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
@@ -46,4 +46,6 @@ class PaddingTermination : FilterNode("Padding termination") {
             addNumber("num_padding_packets_seen", numPaddingPacketsSeen)
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
@@ -48,4 +48,6 @@ class PaddingTermination : FilterNode("Padding termination") {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
@@ -28,4 +28,6 @@ class ProtocolReceiver @JvmOverloads constructor(
     override fun transform(packetInfo: PacketInfo): List<PacketInfo> {
         return stack.processIncomingProtocolData(packetInfo)
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
@@ -30,4 +30,6 @@ class ProtocolReceiver @JvmOverloads constructor(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
@@ -130,4 +130,6 @@ class RemoteBandwidthEstimator(
     fun onRttUpdate(newRttMs: Double) {
         bwe.onRttUpdate(clock.instant(), Duration.ofNanos((newRttMs * 1000_000).toLong()))
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
@@ -132,4 +132,6 @@ class RemoteBandwidthEstimator(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RetransmissionRequesterNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RetransmissionRequesterNode.kt
@@ -39,4 +39,6 @@ class RetransmissionRequesterNode(
         super.stop()
         retransmissionRequester.stop()
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RetransmissionRequesterNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RetransmissionRequesterNode.kt
@@ -41,4 +41,6 @@ class RetransmissionRequesterNode(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -117,4 +117,6 @@ class RtcpTermination(
             addNumber("num_failed_to_forward", numFailedToForward)
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -119,4 +119,6 @@ class RtcpTermination(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -93,4 +93,6 @@ class RtxHandler(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -91,4 +91,6 @@ class RtxHandler(
             addString("rtx_payload_types", rtxPtToRtxPayloadType.values.toString())
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
@@ -47,6 +47,8 @@ class SilenceDiscarder(
                 packetInfo
             }
         }
+
+        override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
     }
 
     inner class RtcpTransformer : TransformerNode("Silence discarder RTCP") {
@@ -63,5 +65,7 @@ class SilenceDiscarder(
 
             return packetInfo
         }
+
+        override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
@@ -49,6 +49,8 @@ class SilenceDiscarder(
         }
 
         override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 
     inner class RtcpTransformer : TransformerNode("Silence discarder RTCP") {
@@ -67,5 +69,7 @@ class SilenceDiscarder(
         }
 
         override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -177,4 +177,6 @@ class TccGeneratorNode(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -175,4 +175,6 @@ class TccGeneratorNode(
             addBoolean("enabled", enabled)
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
@@ -64,4 +64,6 @@ class VideoBitrateCalculator(
             }
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
@@ -66,4 +66,6 @@ class VideoBitrateCalculator(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -82,4 +82,6 @@ class VideoParser(
         }
         super.handleEvent(event)
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -84,4 +84,6 @@ class VideoParser(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -67,4 +67,6 @@ class Vp8Parser(
             addNumber("num_keyframes", numKeyframes)
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -69,4 +69,6 @@ class Vp8Parser(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -52,4 +52,6 @@ class AbsSendTime(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -50,4 +50,6 @@ class AbsSendTime(
             addString("abs_send_time_ext_id", extensionId.toString())
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -46,6 +46,8 @@ class OutgoingStatisticsTracker : ObserverNode("Outgoing statistics tracker") {
     fun getSsrcSnapshot(ssrc: Long): OutgoingSsrcStats.Snapshot? {
         return ssrcStats[ssrc]?.getSnapshot()
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }
 
 class OutgoingStatisticsSnapshot(

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -48,6 +48,8 @@ class OutgoingStatisticsTracker : ObserverNode("Outgoing statistics tracker") {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }
 
 class OutgoingStatisticsSnapshot(

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
@@ -41,4 +41,6 @@ open class ProtocolSender @JvmOverloads constructor(
 
         return null
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
@@ -43,4 +43,6 @@ open class ProtocolSender @JvmOverloads constructor(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
@@ -112,4 +112,6 @@ class RetransmissionSender(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
@@ -110,4 +110,6 @@ class RetransmissionSender(
             addString("rtx_payload_types(orig -> rtx)", this@RetransmissionSender.origPtToRtxPayloadType.toString())
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -37,4 +37,6 @@ class SentRtcpStats : ObserverNode("Sent RTCP stats") {
             }
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -39,4 +39,6 @@ class SentRtcpStats : ObserverNode("Sent RTCP stats") {
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -57,4 +57,6 @@ class TccSeqNumTagger(
             addString("tcc_ext_id", tccExtensionId.toString())
         }
     }
+
+    override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -59,4 +59,6 @@ class TccSeqNumTagger(
     }
 
     override fun detailedNext(packetInfo: PacketInfo) = nextFromChild(packetInfo)
+
+    override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
 }

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -68,12 +68,16 @@ class DtlsTest : ShouldSpec() {
                 pcapWriter?.processPacket(packetInfo)
                 clientReceiver.processPacket(packetInfo)
             }
+
+            override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
         })
         clientSender.attach(object : ConsumerNode("client network") {
             override fun consume(packetInfo: PacketInfo) {
                 pcapWriter?.processPacket(packetInfo)
                 serverReceiver.processPacket(packetInfo)
             }
+
+            override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
         })
 
         // We attach a consumer to each peer's receiver to consume the DTLS app packet
@@ -88,6 +92,8 @@ class DtlsTest : ShouldSpec() {
                 serverReceivedData.complete(receivedStr)
                 serverSender.processPacket(PacketInfo(UnparsedPacket(serverToClientMessage.toByteArray())))
             }
+
+            override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
         })
 
         val clientReceivedData = CompletableFuture<String>()
@@ -98,6 +104,8 @@ class DtlsTest : ShouldSpec() {
                 debug("Client received message: '$receivedStr'")
                 clientReceivedData.complete(receivedStr)
             }
+
+            override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
         })
 
         val serverThread = thread {

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -70,6 +70,8 @@ class DtlsTest : ShouldSpec() {
             }
 
             override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+            override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
         })
         clientSender.attach(object : ConsumerNode("client network") {
             override fun consume(packetInfo: PacketInfo) {
@@ -78,6 +80,8 @@ class DtlsTest : ShouldSpec() {
             }
 
             override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+            override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
         })
 
         // We attach a consumer to each peer's receiver to consume the DTLS app packet
@@ -94,6 +98,8 @@ class DtlsTest : ShouldSpec() {
             }
 
             override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+            override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
         })
 
         val clientReceivedData = CompletableFuture<String>()
@@ -106,6 +112,8 @@ class DtlsTest : ShouldSpec() {
             }
 
             override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+            override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
         })
 
         val serverThread = thread {

--- a/src/test/kotlin/org/jitsi/nlj/resources/node/NodeTestExtensions.kt
+++ b/src/test/kotlin/org/jitsi/nlj/resources/node/NodeTestExtensions.kt
@@ -25,5 +25,7 @@ internal fun Node.onOutput(func: (PacketInfo) -> Unit) {
         override fun consume(packetInfo: PacketInfo) {
             func(packetInfo)
         }
+
+        override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
     })
 }

--- a/src/test/kotlin/org/jitsi/nlj/resources/node/NodeTestExtensions.kt
+++ b/src/test/kotlin/org/jitsi/nlj/resources/node/NodeTestExtensions.kt
@@ -27,5 +27,7 @@ internal fun Node.onOutput(func: (PacketInfo) -> Unit) {
         }
 
         override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+        override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     })
 }

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
@@ -51,6 +51,8 @@ internal class NodeTeardownVisitorTest : ShouldSpec() {
     // terminate at the same node
     private val testOutgoingPipelineTermination = object : ConsumerNode("Output termination") {
         override fun consume(packetInfo: PacketInfo) {}
+
+        override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
     }
 
     private val testOutgoingPipeline1 = pipeline {

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
@@ -53,6 +53,8 @@ internal class NodeTeardownVisitorTest : ShouldSpec() {
         override fun consume(packetInfo: PacketInfo) {}
 
         override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+        override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 
     private val testOutgoingPipeline1 = pipeline {

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
@@ -56,6 +56,8 @@ internal class NodeVisitorTest : ShouldSpec() {
         override fun consume(packetInfo: PacketInfo) {}
 
         override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+        override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 
     private val testOutgoingPipeline1 = pipeline {

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
@@ -54,6 +54,8 @@ internal class NodeVisitorTest : ShouldSpec() {
     // terminate at the same node
     private val testOutgoingPipelineTermination = object : ConsumerNode("Output termination") {
         override fun consume(packetInfo: PacketInfo) {}
+
+        override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
     }
 
     private val testOutgoingPipeline1 = pipeline {

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
@@ -35,6 +35,8 @@ internal class ExclusivePathDemuxerTest : ShouldSpec() {
         }
 
         override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
+
+        override fun detailedPacketDiscarded(packetInfo: PacketInfo) = packetDiscardedFromChild(packetInfo)
     }
 
     private class DummyRtcpPacket : RtcpPacket(ByteArray(50), 0, 50) {

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
@@ -33,6 +33,8 @@ internal class ExclusivePathDemuxerTest : ShouldSpec() {
         override fun consume(packetInfo: PacketInfo) {
             numReceived++
         }
+
+        override fun detailedNext(packetInfo: PacketInfo) = next(packetInfo)
     }
 
     private class DummyRtcpPacket : RtcpPacket(ByteArray(50), 0, 50) {


### PR DESCRIPTION
EDIT: This was intended to be a draft for now. *DO NOT MERGE*.

Playing with a way we can get the child node back into the stack trace, which can be very helpful when debugging.  Not sure this way feels great, but it does accomplish that:
![image (3)](https://user-images.githubusercontent.com/4016469/73389691-92426900-4289-11ea-9dbe-4e97dad85776.png)

This current implementation doesn't feel great to me.  Originally (before the pools and `packetDiscarded` existed) we did have the `Node` implementations call `next` themselves, so we got a really nice stack that included all the specific `Node` types.  When we introduced the `Node` helper classes (`TransformerNode`, `ObserverNode`, etc.) we lost this, but gained the ability to enforce constraints on certain `Node` types, as well as making it easier to implement new `Node`s/harder to screw them up.  It was a worthwhile tradeoff, but I do wonder if there's something we can come up with to get the best of both.  This kinda does that, but the jumping around of the method calls feels pretty convoluted and re-introduces the possibility of messing up a `Node` implementation.  Maybe we can come up with an API that child (as in, the 'leaf' implementation, not the helper classes) can implement to execute invoking next or discarding a buffer which is straightforward enough that the call flow remains reasonable and we don't hinder the helper classes' ability to enforce constraints/make it hard to mess up the implementation of a new Node.

One thing we could do to enforce proper Node implementations that I've done elsewhere is have a unit test which dynamically finds all subclasses of Node and runs some tests on them...this way we could make sure they implemented these functions correctly.