### PR TITLE
Add API to trace packets through the node pipeline.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -135,6 +135,8 @@ class RtpReceiverImpl @JvmOverloads constructor(
         }
 
         override val aggregationKey: String = name
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 
     init {

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -107,6 +107,8 @@ class RtpSenderImpl(
         }
 
         override val aggregationKey = name
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 
     init {

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -183,6 +183,8 @@ class KeyframeRequester @JvmOverloads constructor(
         }
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     override fun getNodeStats(): NodeStatsBlock {
         return super.getNodeStats().apply {
             addString("wait_interval_ms", waitInterval.toMillis().toString())

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpParsers.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpParsers.kt
@@ -26,7 +26,11 @@ class CompoundRtcpParser(parentLogger: Logger) : PacketParser("Compound RTCP par
         // Force packets to be evaluated to trigger any parsing errors
         compoundPacket.packets
     }
-})
+}) {
+    override fun trace(f: () -> Unit) = f.invoke()
+}
 
 class SingleRtcpParser(parentLogger: Logger) : PacketParser("Single RTCP parser", parentLogger, {
-    RtcpPacket.parse(it.buffer, it.offset, it.length) })
+    RtcpPacket.parse(it.buffer, it.offset, it.length) }) {
+    override fun trace(f: () -> Unit) = f.invoke()
+}

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpSrUpdater.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpSrUpdater.kt
@@ -39,4 +39,6 @@ class RtcpSrUpdater(
 
         return packetInfo
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
@@ -61,6 +61,7 @@ class PipelineBuilder {
             }
 
             override val aggregationKey = this.name
+            override fun trace(f: () -> Unit) = f.invoke()
         }
         addNode(node)
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -103,11 +103,7 @@ sealed class Node(
         if (PLUGINS_ENABLED) {
             plugins.forEach { it.observe(this, packetInfo) }
         }
-        if (TRACE_ENABLED) {
-            trace { nextNode?.processPacket(packetInfo) }
-        } else {
-            nextNode?.processPacket(packetInfo)
-        }
+        nextNode?.processPacket(packetInfo)
     }
 
     protected fun next(packetInfos: List<PacketInfo>) {
@@ -115,11 +111,7 @@ sealed class Node(
             if (PLUGINS_ENABLED) {
                 plugins.forEach { it.observe(this, packetInfo) }
             }
-            if (TRACE_ENABLED) {
-                trace { nextNode?.processPacket(packetInfo) }
-            } else {
-                nextNode?.processPacket(packetInfo)
-            }
+            nextNode?.processPacket(packetInfo)
         }
     }
 
@@ -193,7 +185,11 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
 
     override fun processPacket(packetInfo: PacketInfo) {
         onEntry(packetInfo)
-        doProcessPacket(packetInfo)
+        if (TRACE_ENABLED) {
+            trace { doProcessPacket(packetInfo) }
+        } else {
+            doProcessPacket(packetInfo)
+        }
     }
 
     override fun getNodeStats() = NodeStatsBlock("Node $name ${hashCode()}").apply {
@@ -263,11 +259,7 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
 
     protected open fun packetDiscarded(packetInfo: PacketInfo) {
         stats.numDiscardedPackets++
-        if (TRACE_ENABLED) {
-            trace { BufferPool.returnBuffer(packetInfo.packet.buffer) }
-        } else {
-            BufferPool.returnBuffer(packetInfo.packet.buffer)
-        }
+        BufferPool.returnBuffer(packetInfo.packet.buffer)
     }
 
     override fun stop() {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -114,6 +114,16 @@ sealed class Node(
             nextNode?.processPacket(packetInfo)
         }
     }
+    /**
+     * This function must be implemented by leaf nodes, as
+     * ```
+     *     override fun trace(f: () -> Unit) = f.invoke()
+     * ```
+     * or the Java equivalent.  When [NODE_TRACING] is
+     * turned on, this ensures that call stacks always include an method from
+     * the derived class, rather than one of the parent classes.  This can greatly
+     * aid debugging and profiling.
+     */
 
     abstract fun trace(f: () -> Unit)
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
@@ -31,6 +31,8 @@ class PacketCacher : ObserverNode("Packet cache") {
         super.stop()
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     fun getPacketCache(): PacketCache = packetCache
 
     override fun getNodeStats(): NodeStatsBlock {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLoss.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLoss.kt
@@ -45,6 +45,8 @@ class PacketLoss(private val lossRate: Double) : FilterNode("Packet loss") {
             addRatio("actual_drop_rate", "packetsDropped", "packetsSeen")
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }
 
 class BurstPacketLoss(
@@ -73,4 +75,6 @@ class BurstPacketLoss(
             true
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
@@ -36,4 +36,6 @@ open class PacketParser(
             null
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PacketStreamStatsNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PacketStreamStatsNode.kt
@@ -30,6 +30,8 @@ class PacketStreamStatsNode(private val packetStreamStats: PacketStreamStats = P
         packetStreamStats.update(packetInfo.packet.length)
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     fun snapshot() = packetStreamStats.snapshot()
 
     fun getBitrate() = snapshot().bitrate

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
@@ -91,6 +91,8 @@ class PcapWriter(
         writer.dump(eth)
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     fun close() {
         if (lazyWriter.isInitialized() && writer.isOpen) {
             writer.close()

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
@@ -49,4 +49,6 @@ class RtpParser(
         packetInfo.resetPayloadVerification()
         return packetInfo
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -144,7 +144,18 @@ abstract class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode
     }
 }
 
-class SrtcpDecryptNode : SrtpTransformerNode("SRTCP Decrypt Node")
-class SrtcpEncryptNode : SrtpTransformerNode("SRTCP Encrypt Node")
-class SrtpDecryptNode : SrtpTransformerNode("SRTP Decrypt Node")
-class SrtpEncryptNode : SrtpTransformerNode("SRTP Encrypt Node")
+class SrtcpDecryptNode : SrtpTransformerNode("SRTCP Decrypt Node") {
+    override fun trace(f: () -> Unit) = f.invoke()
+}
+
+class SrtcpEncryptNode : SrtpTransformerNode("SRTCP Encrypt Node") {
+    override fun trace(f: () -> Unit) = f.invoke()
+}
+
+class SrtpDecryptNode : SrtpTransformerNode("SRTP Decrypt Node") {
+    override fun trace(f: () -> Unit) = f.invoke()
+}
+
+class SrtpEncryptNode : SrtpTransformerNode("SRTP Encrypt Node") {
+    override fun trace(f: () -> Unit) = f.invoke()
+}

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -67,5 +67,7 @@ class ToggleablePcapWriter(
                 }
             }
         }
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/debug/RtpPacketTraceNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/debug/RtpPacketTraceNode.kt
@@ -25,4 +25,6 @@ class RtpPacketTraceNode(val where: String) : ObserverNode("RtpPacketTraceNode@$
         val rtpPacket = packetInfo.packetAs<RtpPacket>()
         println("$where: RTP packet ${rtpPacket.ssrc} ${rtpPacket.sequenceNumber}")
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -64,4 +64,6 @@ class AudioLevelReader(
             addString("audio_level_ext_id", audioLevelExtId.toString())
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -66,6 +66,8 @@ class IncomingStatisticsTracker(
      */
     override fun getNodeStatsToAggregate() = super.getNodeStats()
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     fun getSnapshot(): IncomingStatisticsSnapshot {
         return IncomingStatisticsSnapshot(
             ssrcStats.map { (ssrc, stats) ->

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
@@ -46,4 +46,6 @@ class PaddingTermination : FilterNode("Padding termination") {
             addNumber("num_padding_packets_seen", numPaddingPacketsSeen)
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/ProtocolReceiver.kt
@@ -28,4 +28,6 @@ class ProtocolReceiver @JvmOverloads constructor(
     override fun transform(packetInfo: PacketInfo): List<PacketInfo> {
         return stack.processIncomingProtocolData(packetInfo)
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
@@ -88,6 +88,8 @@ class RemoteBandwidthEstimator(
         }
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     override fun observe(packetInfo: PacketInfo) {
         if (!enabled) return
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RetransmissionRequesterNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RetransmissionRequesterNode.kt
@@ -39,4 +39,6 @@ class RetransmissionRequesterNode(
         super.stop()
         retransmissionRequester.stop()
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -117,4 +117,6 @@ class RtcpTermination(
             addNumber("num_failed_to_forward", numFailedToForward)
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -91,4 +91,6 @@ class RtxHandler(
             addString("rtx_payload_types", rtxPtToRtxPayloadType.values.toString())
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/SilenceDiscarder.kt
@@ -47,6 +47,8 @@ class SilenceDiscarder(
                 packetInfo
             }
         }
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 
     inner class RtcpTransformer : TransformerNode("Silence discarder RTCP") {
@@ -63,5 +65,7 @@ class SilenceDiscarder(
 
             return packetInfo
         }
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -167,6 +167,8 @@ class TccGeneratorNode(
         running = false
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     override fun getNodeStats(): NodeStatsBlock {
         return super.getNodeStats().apply {
             addNumber("num_tcc_packets_sent", numTccSent)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoBitrateCalculator.kt
@@ -64,4 +64,6 @@ class VideoBitrateCalculator(
             }
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -82,4 +82,6 @@ class VideoParser(
         }
         super.handleEvent(event)
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -67,4 +67,6 @@ class Vp8Parser(
             addNumber("num_keyframes", numKeyframes)
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -50,4 +50,6 @@ class AbsSendTime(
             addString("abs_send_time_ext_id", extensionId.toString())
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -35,6 +35,8 @@ class OutgoingStatisticsTracker : ObserverNode("Outgoing statistics tracker") {
         stats.packetSent(rtpPacket.length, rtpPacket.timestamp)
     }
 
+    override fun trace(f: () -> Unit) = f.invoke()
+
     fun getSnapshot(): OutgoingStatisticsSnapshot {
         return OutgoingStatisticsSnapshot(
             ssrcStats.map { (ssrc, stats) ->

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProtocolSender.kt
@@ -41,4 +41,6 @@ open class ProtocolSender @JvmOverloads constructor(
 
         return null
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
@@ -110,4 +110,6 @@ class RetransmissionSender(
             addString("rtx_payload_types(orig -> rtx)", this@RetransmissionSender.origPtToRtxPayloadType.toString())
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -37,4 +37,6 @@ class SentRtcpStats : ObserverNode("Sent RTCP stats") {
             }
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -57,4 +57,6 @@ class TccSeqNumTagger(
             addString("tcc_ext_id", tccExtensionId.toString())
         }
     }
+
+    override fun trace(f: () -> Unit) = f.invoke()
 }

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -68,12 +68,16 @@ class DtlsTest : ShouldSpec() {
                 pcapWriter?.processPacket(packetInfo)
                 clientReceiver.processPacket(packetInfo)
             }
+
+            override fun trace(f: () -> Unit) = f.invoke()
         })
         clientSender.attach(object : ConsumerNode("client network") {
             override fun consume(packetInfo: PacketInfo) {
                 pcapWriter?.processPacket(packetInfo)
                 serverReceiver.processPacket(packetInfo)
             }
+
+            override fun trace(f: () -> Unit) = f.invoke()
         })
 
         // We attach a consumer to each peer's receiver to consume the DTLS app packet
@@ -88,6 +92,8 @@ class DtlsTest : ShouldSpec() {
                 serverReceivedData.complete(receivedStr)
                 serverSender.processPacket(PacketInfo(UnparsedPacket(serverToClientMessage.toByteArray())))
             }
+
+            override fun trace(f: () -> Unit) = f.invoke()
         })
 
         val clientReceivedData = CompletableFuture<String>()
@@ -98,6 +104,8 @@ class DtlsTest : ShouldSpec() {
                 debug("Client received message: '$receivedStr'")
                 clientReceivedData.complete(receivedStr)
             }
+
+            override fun trace(f: () -> Unit) = f.invoke()
         })
 
         val serverThread = thread {

--- a/src/test/kotlin/org/jitsi/nlj/resources/node/NodeTestExtensions.kt
+++ b/src/test/kotlin/org/jitsi/nlj/resources/node/NodeTestExtensions.kt
@@ -25,5 +25,7 @@ internal fun Node.onOutput(func: (PacketInfo) -> Unit) {
         override fun consume(packetInfo: PacketInfo) {
             func(packetInfo)
         }
+
+        override fun trace(f: () -> Unit) = f.invoke()
     })
 }

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
@@ -51,6 +51,8 @@ internal class NodeTeardownVisitorTest : ShouldSpec() {
     // terminate at the same node
     private val testOutgoingPipelineTermination = object : ConsumerNode("Output termination") {
         override fun consume(packetInfo: PacketInfo) {}
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 
     private val testOutgoingPipeline1 = pipeline {

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
@@ -54,6 +54,8 @@ internal class NodeVisitorTest : ShouldSpec() {
     // terminate at the same node
     private val testOutgoingPipelineTermination = object : ConsumerNode("Output termination") {
         override fun consume(packetInfo: PacketInfo) {}
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 
     private val testOutgoingPipeline1 = pipeline {

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
@@ -33,6 +33,8 @@ internal class ExclusivePathDemuxerTest : ShouldSpec() {
         override fun consume(packetInfo: PacketInfo) {
             numReceived++
         }
+
+        override fun trace(f: () -> Unit) = f.invoke()
     }
 
     private class DummyRtcpPacket : RtcpPacket(ByteArray(50), 0, 50) {


### PR DESCRIPTION
This allows the specific nodes to show up in stack traces (and profilers, etc).

Nodes must now implement a trivial 'trace' method which just invokes its lambda.

(This is similar but somewhat simpler than https://github.com/jitsi/jitsi-media-transform/pull/200.)

![Screen Shot 2020-01-29 at 3 38 01 PM](https://user-images.githubusercontent.com/4006649/73395406-6df88380-42ad-11ea-8587-419cc7a41387.png)

TODO: for some reason the `org.jitsi.nlj.transform.node.Node$next$2.invoke()` call shows up twice in the stack - once for the base Node and once for the child node.