### PR TITLE
Use simple names for sent rtcp packet types.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -16,18 +16,17 @@
 
 package org.jitsi.nlj.transform.node.outgoing
 
-import kotlin.reflect.KClass
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ObserverNode
 import org.jitsi.rtp.rtcp.RtcpPacket
 
 class SentRtcpStats : ObserverNode("Sent RTCP stats") {
-    private var sentRtcpCounts = mutableMapOf<KClass<out RtcpPacket>, Int>().withDefault { 0 }
+    private var sentRtcpCounts = mutableMapOf<String, Int>()
 
     override fun observe(packetInfo: PacketInfo) {
         val rtcpPacket: RtcpPacket = packetInfo.packetAs()
-        sentRtcpCounts[rtcpPacket::class] = (sentRtcpCounts[rtcpPacket::class] ?: 0) + 1
+        sentRtcpCounts.merge(rtcpPacket::class.simpleName!!, 1, Int::plus)
     }
 
     override fun getNodeStats(): NodeStatsBlock {


### PR DESCRIPTION
This mirrors the code in `RtcpTermination` and produces this:
```
 "num_RtcpFbPliPacket_tx": 88,
  "num_RtcpFbTccPacket_tx": 301,
  "num_RtcpRrPacket_tx": 19,
  "num_RtcpSrPacket_tx": 11,
  "num_RtcpFbNackPacket_tx": 234,
```


Before it produced this:
```
"num_class org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket_tx": 635,
"num_class org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.RtcpFbNackPacket_tx": 12595,
"num_class org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket_tx": 12140,
"num_class org.jitsi.rtp.rtcp.RtcpRrPacket_tx": 2996,
```