### PR TITLE
Warn for negative round trip times.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -113,7 +113,12 @@ class EndpointConnectionStats(
             rtt = (Duration.between(srSentTime, receivedTime) - remoteProcessingDelay).toDoubleMillis()
             if (rtt > Duration.ofSeconds(7).toMillis()) {
                 logger.warn("Suspiciously high rtt value: $rtt, remote processing delay was " +
-                    "$remoteProcessingDelay ms, srSentTime was $srSentTime, received time was $receivedTime")
+                    "$remoteProcessingDelay, srSentTime was $srSentTime, received time was $receivedTime")
+            } else if (rtt < 0) {
+                // Should we allow a small slop here, in case the reporter's clock is running faster
+                // than ours? If so, how much?
+                logger.warn("Negative rtt value: $rtt, remote processing delay was " +
+                    "$remoteProcessingDelay, srSentTime was $srSentTime, received time was $receivedTime")
             }
             endpointConnectionStatsListeners.forEach { it.onRttUpdate(rtt) }
         } ?: run {


### PR DESCRIPTION
Also clean up a log message (spurious "ms" after a logged Duration).

Note that it seems we *are* getting negative rtt's: `AimdRateControl`'s `java.lang.IllegalArgumentException: responseTimeMs` will trigger if rtt is < -100 ms.