### PR TITLE
Log if a VP8 packet lacks a pictureId, has a short picture ID, or lacks a TL0PICIDX.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>rtp</artifactId>
-            <version>1.0-42-gc2cd0a2</version>
+            <version>1.0-43-g1ee1a7c</version>
         </dependency>
         <dependency>
             <groupId>org.jitsi</groupId>

--- a/src/main/java/org/jitsi_modified/impl/neomedia/codec/video/vp8/DePacketizer.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/codec/video/vp8/DePacketizer.java
@@ -121,6 +121,35 @@ public class DePacketizer
         private static final byte N_BIT = (byte) 0x20;
 
         /**
+         * Gets whether a VP8 payload has a temporal layer index (TID).
+         *
+         * @param buf the byte buffer that holds the VP8 packet.
+         * @param off the offset in the byte buffer where the VP8 payload starts.
+         * @param len the length of the VP8 payload.
+         * @return true if the VP8 payload has a temporal layer index, false if not.
+         */
+        public static boolean hasTemporalLayerIndex(byte[] buf, int off, int len)
+        {
+            if (buf == null || buf.length < off + len || len < 2)
+            {
+                return false;
+            }
+
+            if ((buf[off] & X_BIT) == 0 || (buf[off + 1] & T_BIT) == 0)
+            {
+                return false;
+            }
+
+            int sz = getSize(buf, off, len);
+            if (buf.length < off + sz || sz < 1)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /**
          * Gets the temporal layer index (TID), if that's set.
          *
          * @param buf the byte buffer that holds the VP8 packet.

--- a/src/main/java/org/jitsi_modified/impl/neomedia/codec/video/vp8/DePacketizer.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/codec/video/vp8/DePacketizer.java
@@ -130,23 +130,7 @@ public class DePacketizer
          */
         public static boolean hasTemporalLayerIndex(byte[] buf, int off, int len)
         {
-            if (buf == null || buf.length < off + len || len < 2)
-            {
-                return false;
-            }
-
-            if ((buf[off] & X_BIT) == 0 || (buf[off + 1] & T_BIT) == 0)
-            {
-                return false;
-            }
-
-            int sz = getSize(buf, off, len);
-            if (buf.length < off + sz || sz < 1)
-            {
-                return false;
-            }
-
-            return true;
+            return getTemporalLayerIndex(buf, off, len) != -1;
         }
 
         /**

--- a/src/main/java/org/jitsi_modified/impl/neomedia/codec/video/vp8/DePacketizer.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/codec/video/vp8/DePacketizer.java
@@ -294,6 +294,22 @@ public class DePacketizer
         }
 
         /**
+         * Determines whether the VP8 payload specified in the buffer that is
+         * passed as an argument has a TL0PICIDX or not.
+         *
+         * @param buf the byte buffer that contains the VP8 payload.
+         * @param off the offset in the byte buffer where the VP8 payload
+         *            starts.
+         * @param len the length of the VP8 payload in the byte buffer.
+         * @return true if the VP8 payload contains a TL0PICIDX,
+         * false otherwise.
+         */
+        public static boolean hasTL0PICIDX(byte[] buf, int off, int len)
+        {
+            return getLByteOffset(buf, off, len) >= 0;
+        }
+
+        /**
          * Gets the value of the PictureID field of a VP8 Payload Descriptor.
          *
          * @param input

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -67,6 +67,12 @@ class Vp8Packet private constructor (
         /** This uses [get] rather than initialization because [isMarked] is a var. */
         get() = isMarked
 
+    val hasPictureId = DePacketizer.VP8PayloadDescriptor.hasPictureId(buffer, payloadOffset, payloadLength)
+
+    val hasExtendedPictureId = DePacketizer.VP8PayloadDescriptor.hasExtendedPictureId(buffer, payloadOffset, payloadLength)
+
+    val hasTL0PICIDX = DePacketizer.VP8PayloadDescriptor.hasTL0PICIDX(buffer, payloadOffset, payloadLength)
+
     var TL0PICIDX: Int by Delegates.observable(TL0PICIDX ?: DePacketizer.VP8PayloadDescriptor.getTL0PICIDX(buffer, payloadOffset, payloadLength)) {
         _, _, newValue ->
             if (!DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -67,6 +67,8 @@ class Vp8Packet private constructor (
         /** This uses [get] rather than initialization because [isMarked] is a var. */
         get() = isMarked
 
+    val hasTemporalLayerIndex = DePacketizer.VP8PayloadDescriptor.hasTemporalLayerIndex(buffer, payloadOffset, payloadLength)
+
     val hasPictureId = DePacketizer.VP8PayloadDescriptor.hasPictureId(buffer, payloadOffset, payloadLength)
 
     val hasExtendedPictureId = DePacketizer.VP8PayloadDescriptor.hasExtendedPictureId(buffer, payloadOffset, payloadLength)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -66,8 +66,8 @@ class Vp8Parser(
                 logger.cinfo { "Packet $videoRtpPacket has 7-bit (short) picture ID.  Packet data: ${videoRtpPacket.toHex(80)}" }
             }
 
-            if (!videoRtpPacket.hasTL0PICIDX) {
-                logger.cinfo { "Packet $videoRtpPacket does not have TL0PICIDX.  Packet data: ${videoRtpPacket.toHex(80)}" }
+            if (videoRtpPacket.hasTemporalLayerIndex && !videoRtpPacket.hasTL0PICIDX) {
+                logger.cinfo { "Packet $videoRtpPacket has TID but does not have TL0PICIDX.  Packet data: ${videoRtpPacket.toHex(80)}" }
             }
         }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -21,7 +21,9 @@ import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.rtp.codec.vp8.Vp8Packet
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ModifierNode
+import org.jitsi.rtp.extensions.toHex
 import org.jitsi.utils.logging2.cdebug
+import org.jitsi.utils.logging2.cinfo
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 
@@ -56,6 +58,16 @@ class Vp8Parser(
             if (videoRtpPacket.isKeyframe) {
                 logger.cdebug { "Received a keyframe for ssrc ${videoRtpPacket.ssrc} ${videoRtpPacket.sequenceNumber}" }
                 numKeyframes++
+            }
+
+            if (!videoRtpPacket.hasPictureId) {
+                logger.cinfo { "Packet $videoRtpPacket does not have picture ID.  Packet data: ${videoRtpPacket.toHex(80)}" }
+            } else if (!videoRtpPacket.hasExtendedPictureId) {
+                logger.cinfo { "Packet $videoRtpPacket has 7-bit (short) picture ID.  Packet data: ${videoRtpPacket.toHex(80)}" }
+            }
+
+            if (!videoRtpPacket.hasTL0PICIDX) {
+                logger.cinfo { "Packet $videoRtpPacket does not have TL0PICIDX.  Packet data: ${videoRtpPacket.toHex(80)}" }
             }
         }
 


### PR DESCRIPTION
Note this depends on https://github.com/jitsi/jitsi-rtp/pull/75.