### PR TITLE
Set qualityIndex on all videoPackets, regardless of payload type.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -67,6 +67,9 @@ class VideoParser(
                     packetInfo.packet = vp8Packet
                     packetInfo.resetPayloadVerification()
                 }
+                else -> {
+                    videoPacket.qualityIndex = encodingDesc.index
+                }
             }
         } catch (e: Exception) {
             logger.error("Exception parsing video packet.  Packet data is: ${videoPacket.buffer.toHex(videoPacket.offset, Math.min(videoPacket.length, 80))}", e)


### PR DESCRIPTION
I believe this should allow the bridge to forward H.264 and VP9, albeit with the Generic track projection context.