### PR TITLE
Don't do TCC for audio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>rtp</artifactId>
-            <version>1.0-43-g1ee1a7c</version>
+            <version>1.0-44-g1895474</version>
         </dependency>
         <dependency>
             <groupId>org.jitsi</groupId>

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -18,6 +18,7 @@ package org.jitsi.nlj.transform.node.outgoing
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.RtpExtensionType.TRANSPORT_CC
 import org.jitsi.nlj.rtp.TransportCcEngine
+import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ModifierNode
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
@@ -41,12 +42,14 @@ class TccSeqNumTagger(
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         tccExtensionId?.let { tccExtId ->
             val rtpPacket = packetInfo.packetAs<RtpPacket>()
-            val ext = rtpPacket.getHeaderExtension(tccExtId)
-                ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
+            if (rtpPacket is VideoRtpPacket) {
+                val ext = rtpPacket.getHeaderExtension(tccExtId)
+                    ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
 
-            TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
-            transportCcEngine?.mediaPacketSent(currTccSeqNum, rtpPacket.length.bytes)
-            currTccSeqNum++
+                TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
+                transportCcEngine?.mediaPacketSent(currTccSeqNum, rtpPacket.length.bytes)
+                currTccSeqNum++
+            }
         }
 
         return packetInfo

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -41,14 +41,24 @@ class TccSeqNumTagger(
 
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         tccExtensionId?.let { tccExtId ->
-            val rtpPacket = packetInfo.packetAs<RtpPacket>()
-            if (rtpPacket is VideoRtpPacket) {
-                val ext = rtpPacket.getHeaderExtension(tccExtId)
-                    ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
+            when (val rtpPacket = packetInfo.packetAs<RtpPacket>()) {
+                is VideoRtpPacket -> {
+                    val ext = rtpPacket.getHeaderExtension(tccExtId)
+                        ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
 
-                TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
-                transportCcEngine?.mediaPacketSent(currTccSeqNum, rtpPacket.length.bytes)
-                currTccSeqNum++
+                    TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
+                    transportCcEngine?.mediaPacketSent(currTccSeqNum, rtpPacket.length.bytes)
+                    currTccSeqNum++
+                }
+                else -> {
+                    rtpPacket.getHeaderExtension(tccExtId)?.let {
+                        // This is a hack: we don't want to do TCC for audio (since some browsers
+                        // don't support it) but we don't want to strip the existing extension
+                        // either (as its costly), so we merely change its ID to something we
+                        // know (based on Jicofo's offer) is unused.
+                        it.id = 14
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Some browsers don't support TCC for audio, so this is a quick-and-dirty hack to disable it for audio all the time.  In order to do this, we need to not include the audio packets in the outgoing TCC sequence number space, but make sure to 'clear' any existing TCC extension on audio packets.  Because removing header extensions is costly, we do this by hard-coding the extension ID to one that we know it isn't signaled.