### PR TITLE
Use ${project.groupId} to refer to org.jitsi.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,27 +24,27 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jitsi</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-srtp</artifactId>
             <version>1.0-20-g513e4e3</version>
         </dependency>
         <dependency>
-            <groupId>org.jitsi</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>rtp</artifactId>
             <version>1.0-44-g1895474</version>
         </dependency>
         <dependency>
-            <groupId>org.jitsi</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-utils</artifactId>
             <version>${jitsi.utils.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jitsi</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-utils-kotlin</artifactId>
             <version>${jitsi.utils.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jitsi</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jicoco-kotlin</artifactId>
             <version>1.1-22-gbec9167</version>
         </dependency>


### PR DESCRIPTION
I've noticed that sometimes `org.jitsi` is referred as `${project.groupId}` and sometimes it is hardcoded among Jitsi's poms. 
I prefer consistency and personally like `${project.groupId}` more. 
So this PR is just one of several I'm planning to different repos to make things consistent.
I hope you won't mind me doing this :) 