### PR TITLE
Added test to reveal suspicious behavior of enum

### DIFF
--- a/src/test/kotlin/org/jitsi/nlj/format/PayloadTypeEncodingTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/format/PayloadTypeEncodingTest.kt
@@ -39,7 +39,12 @@ internal class PayloadTypeEncodingTest : ShouldSpec() {
                 encoding2 shouldBe encoding3
             }
             should("return OTHER in the invalid case") {
-                PayloadTypeEncoding.createFrom("blah") shouldBe PayloadTypeEncoding.OTHER
+                val fooPt = PayloadTypeEncoding.createFrom("foo")
+                val barPt = PayloadTypeEncoding.createFrom("bar")
+                fooPt shouldBe PayloadTypeEncoding.OTHER
+                barPt shouldBe PayloadTypeEncoding.OTHER
+                fooPt.unknownVal shouldBe "foo"
+                barPt.unknownVal shouldBe "bar"
             }
         }
     }


### PR DESCRIPTION
I've extended test for `PayloadType` enum to reveal very suspicious and probably incorrect behavior.
I would expect that `unknownVal` would hold the unknown payload type name passed into `createFrom`, but it only stores unknown value of last value passed in `createFrom`. This seems to be very dangerous and error prone, because of unexpected global mutable state which is `unknownVal`.

I could not find any meaningful usage of `unknownVal` in code base, so maybe it make sense to remove it completely? I've checked that just removing `unknownVal` from tests and definition succeeds all other tests, so it seems `unknownVal` unused.

It also seem to be that when`unknownVal` field is removed two values of `OTHER` must always be unequal (the same as `NaN` in floating point arithmetic), hence it probably make sense to override equals as well to match an expectation.

What do you think?

May I at least provide PR removing `unknownVal`?