### PR TITLE
Record tcc timestamps when packets are sent

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -143,9 +143,7 @@ open class PacketInfo @JvmOverloads constructor(
     }
 
     /**
-     * The list of pending actions.
-     *
-     * We use [LinkedList] because it is the lightest-weight if no actions are added.
+     * The list of pending actions, or [null] if none.
      */
     private var onSentActions: ArrayList<() -> Unit>? = null
 

--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -17,6 +17,7 @@ package org.jitsi.nlj
 
 import java.time.Duration
 import org.jitsi.rtp.Packet
+import java.util.Collections
 
 class EventTimeline(
     private val timeline: MutableList<Pair<String, Long>> = mutableListOf()
@@ -169,11 +170,11 @@ open class PacketInfo @JvmOverloads constructor(
      * method.  This should be called just before, or after, this packet is sent.
      */
     fun sent() {
-        var actions: List<() -> Unit>? = null
+        var actions: List<() -> Unit> = Collections.emptyList()
         synchronized(this) {
             onSentActions?.let { actions = it; onSentActions = null } ?: run { return@sent }
         }
-        for (action in actions!!) {
+        for (action in actions) {
             action.invoke()
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -25,9 +25,10 @@ import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.bytes
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.TccHeaderExtension
+import java.lang.ref.WeakReference
 
 class TccSeqNumTagger(
-    private val transportCcEngine: TransportCcEngine? = null,
+    transportCcEngine: TransportCcEngine? = null,
     streamInformationStore: ReadOnlyStreamInformationStore
 ) : ModifierNode("TCC sequence number tagger") {
     private var currTccSeqNum: Int = 1
@@ -39,6 +40,8 @@ class TccSeqNumTagger(
         }
     }
 
+    private val weakTcc = WeakReference(transportCcEngine)
+
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         tccExtensionId?.let { tccExtId ->
             when (val rtpPacket = packetInfo.packetAs<RtpPacket>()) {
@@ -47,7 +50,8 @@ class TccSeqNumTagger(
                         ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
 
                     TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
-                    transportCcEngine?.mediaPacketSent(currTccSeqNum, rtpPacket.length.bytes)
+                    val len = rtpPacket.length.bytes
+                    packetInfo.onSent { weakTcc.get()?.mediaPacketSent(currTccSeqNum, len) }
                     currTccSeqNum++
                 }
                 else -> {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -50,8 +50,11 @@ class TccSeqNumTagger(
                         ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
 
                     TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
+
+                    val curSeq = currTccSeqNum
                     val len = rtpPacket.length.bytes
-                    packetInfo.onSent { weakTcc.get()?.mediaPacketSent(currTccSeqNum, len) }
+                    packetInfo.onSent { weakTcc.get()?.mediaPacketSent(curSeq, len) }
+
                     currTccSeqNum++
                 }
                 else -> {


### PR DESCRIPTION
This makes sure we don't treat internal packet queueing times as network congestion, causing us to reduce sending bandwidth.