### PR TITLE
Expose readonly version of stream information store

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -32,6 +32,7 @@ import org.jitsi.nlj.stats.PacketIOActivity
 import org.jitsi.nlj.stats.TransceiverStats
 import org.jitsi.nlj.transform.NodeStatsProducer
 import org.jitsi.nlj.util.LocalSsrcAssociation
+import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.SsrcAssociation
 import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.utils.logging2.cdebug
@@ -73,6 +74,7 @@ class Transceiver(
     val packetIOActivity = PacketIOActivity()
     private val endpointConnectionStats = EndpointConnectionStats(logger)
     private val streamInformationStore = StreamInformationStoreImpl()
+    val readOnlyStreamInformationStore: ReadOnlyStreamInformationStore = streamInformationStore
     /**
      * A central place to subscribe to be notified on the reception or transmission of RTCP packets for
      * this transceiver.  This is intended to be used by internal entities: mainly logic for things like generating

--- a/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
@@ -18,6 +18,7 @@ package org.jitsi.nlj.util
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.Collections
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.format.supportsPli
 import org.jitsi.nlj.format.supportsRemb
@@ -105,8 +106,7 @@ class StreamInformationStoreImpl : StreamInformationStore {
     private val payloadTypesLock = Any()
     private val payloadTypeHandlers = mutableListOf<RtpPayloadTypesChangedHandler>()
     private val _rtpPayloadTypes: MutableMap<Byte, PayloadType> = ConcurrentHashMap()
-    override val rtpPayloadTypes: Map<Byte, PayloadType>
-        get() = _rtpPayloadTypes
+    override val rtpPayloadTypes: Map<Byte, PayloadType> = Collections.unmodifiableMap(_rtpPayloadTypes)
 
     private val localSsrcAssociations = SsrcAssociationStore("Local SSRC Associations")
     private val remoteSsrcAssociations = SsrcAssociationStore("Remote SSRC Associations")


### PR DESCRIPTION
I've added exposing read only version of stream information store from endpoint as suggested by @bbaldino which is later planned to be use as a source of endpoint's payload types.

This is a little step toward to support of endpoints with different codec payload types.

Original problem is raised here: https://github.com/jitsi/jitsi-videobridge/issues/1163