### PR TITLE
Add config to lock down REST API for PCAP capture

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jitsi.config.newConfigAttributes
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.FeatureToggleEvent
 import org.jitsi.nlj.Features
@@ -21,7 +22,9 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.Node
 import org.jitsi.nlj.transform.node.ObserverNode
 import org.jitsi.nlj.transform.node.PcapWriter
+import org.jitsi.utils.config.SimpleProperty
 import org.jitsi.utils.logging2.Logger
+import java.security.AccessControlException
 import java.util.Date
 
 class ToggleablePcapWriter(
@@ -33,6 +36,10 @@ class ToggleablePcapWriter(
     private val pcapLock = Any()
 
     fun enable() {
+        if (!PcapWriterConfig.Config.pcapEnabled()) {
+            // TODO: is this the right exception type, semantically?
+            throw AccessControlException("PCAP capture is disabled in configuration")
+        }
         synchronized(pcapLock) {
             if (pcapWriter == null) {
                 pcapWriter = PcapWriter(parentLogger, "/tmp/$prefix-${Date().toInstant()}.pcap")
@@ -69,5 +76,24 @@ class ToggleablePcapWriter(
         }
 
         override fun trace(f: () -> Unit) = f.invoke()
+    }
+}
+
+class PcapWriterConfig {
+    class Config {
+        companion object {
+
+            class PcapEnabledProperty : SimpleProperty<Boolean>(
+                newConfigAttributes {
+                    readOnce()
+                    name("jmt.pcap.enabled")
+                }
+            )
+            private val pcapEnabledProperty =
+                PcapEnabledProperty()
+
+            @JvmStatic
+            fun pcapEnabled(): Boolean = pcapEnabledProperty.value
+        }
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -24,7 +24,7 @@ import org.jitsi.nlj.transform.node.ObserverNode
 import org.jitsi.nlj.transform.node.PcapWriter
 import org.jitsi.utils.config.SimpleProperty
 import org.jitsi.utils.logging2.Logger
-import java.security.AccessControlException
+import java.lang.IllegalStateException
 import java.util.Date
 
 class ToggleablePcapWriter(
@@ -37,8 +37,7 @@ class ToggleablePcapWriter(
 
     fun enable() {
         if (!PcapWriterConfig.Config.pcapEnabled()) {
-            // TODO: is this the right exception type, semantically?
-            throw AccessControlException("PCAP capture is disabled in configuration")
+            throw IllegalStateException("PCAP capture is disabled in configuration")
         }
         synchronized(pcapLock) {
             if (pcapWriter == null) {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -46,4 +46,10 @@ jmt {
         queue-size=1024
       }
   }
+
+  pcap {
+    # Whether the API to dynamically enable capturing unencrypted PCAP files
+    # of media traffic is permitted.
+    enabled=false
+  }
 }


### PR DESCRIPTION
This makes sure that the PCAP capture REST API won't work unless explicitly enabled in the jvb config.