### PR TITLE
Fix various buffer pool leaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <kotlintest.version>3.4.2</kotlintest.version>
         <junit.version>5.2.0</junit.version>
         <bouncycastle.version>1.61</bouncycastle.version>
-        <jitsi.utils.version>1.0-38-g5badf5f</jitsi.utils.version>
+        <jitsi.utils.version>1.0-44-gba9ad73</jitsi.utils.version>
         <ktlint.skip>false</ktlint.skip>
     </properties>
     <dependencies>

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -15,9 +15,6 @@
  */
 package org.jitsi.nlj
 
-import java.time.Clock
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.ScheduledExecutorService
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtp.RtpExtension
@@ -35,13 +32,16 @@ import org.jitsi.nlj.util.LocalSsrcAssociation
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.SsrcAssociation
 import org.jitsi.nlj.util.StreamInformationStoreImpl
-import org.jitsi.utils.logging2.cdebug
-import org.jitsi.utils.logging2.cinfo
-import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.cdebug
+import org.jitsi.utils.logging2.cinfo
+import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi_modified.impl.neomedia.rtp.MediaStreamTrackDesc
+import java.time.Clock
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
 
 // This is an API class, so its usages will largely be outside of this library
 @Suppress("unused")
@@ -312,6 +312,7 @@ class Transceiver(
     }
 
     fun teardown() {
+        logger.info("Tearing down")
         rtpReceiver.tearDown()
         rtpSender.tearDown()
     }

--- a/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -199,7 +199,11 @@ class DtlsStack(
         }
     }
 
-    override fun close() {}
+    override fun close() {
+        incomingProtocolData.forEach {
+            BufferPool.returnBuffer(it.packet.buffer)
+        }
+    }
 
     /**
      * Receive limit computation copied from [org.bouncycastle.crypto.tls.UDPTransport]

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/NackHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/NackHandler.kt
@@ -20,6 +20,7 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.stats.EndpointConnectionStats
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.NodeStatsProducer
+import org.jitsi.nlj.util.BufferPool
 import org.jitsi.nlj.util.PacketCache
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
@@ -72,6 +73,7 @@ class NackHandler(
                     packetCache.updateTimestamp(ssrc, missingSeqNum, now)
                     numRetransmittedPackets++
                 } else {
+                    BufferPool.returnBuffer(container.item!!.buffer)
                     numPacketsNotResentDueToDelay++
                 }
             } ?: run {

--- a/src/main/kotlin/org/jitsi/nlj/util/PacketInfoQueue.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/PacketInfoQueue.kt
@@ -16,9 +16,9 @@
 
 package org.jitsi.nlj.util
 
-import java.util.concurrent.ExecutorService
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.utils.queue.PacketQueue
+import java.util.concurrent.ExecutorService
 
 /**
  * A [PacketInfo] queue. We do not want to use the copy functionality, which is why the related
@@ -30,6 +30,10 @@ class PacketInfoQueue(
     handler: (PacketInfo) -> Boolean,
     capacity: Int = 1024
 ) : PacketQueue<PacketInfo>(capacity, false, null, id, handler, executor) {
+    override fun releasePacket(pkt: PacketInfo) {
+        BufferPool.returnBuffer(pkt.packet.buffer)
+    }
+
     override fun getBuffer(packetInfo: PacketInfo): ByteArray =
         throw NotImplementedError("copy=true is not supported")
 


### PR DESCRIPTION
This depends on https://github.com/jitsi/jitsi-utils/pull/53

This PR covers a bunch of cases where we have a buffer from the pool but it never gets returned.  Combined with the jitsi-utils PR above and a JVB PR (https://github.com/jitsi/jitsi-videobridge/pull/1184), I've been able to get us down to 0 outstanding buffers in my testing.