### PR TITLE
Be tolerant of tl0picidx values of -1 (meaning value not found).

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/codec/vp8/Vp8Utils.kt
+++ b/src/main/kotlin/org/jitsi/nlj/codec/vp8/Vp8Utils.kt
@@ -116,10 +116,13 @@ class Vp8Utils {
          * picture IDs in the form of the number you'd add to b to get a. e.g.:
          * getTl0PicIdxDelta(1, 10) -> -9 (10 + -9 = 1)
          * getTl0PicIdxDelta(1, 250) -> 7 (250 + 7 = 1)
+         *
+         * If either value is -1 (meaning tl0picidx not found) return 0.
          * @return the delta between two extended picture IDs (modulo 2^8).
          */
         @JvmStatic
         fun getTl0PicIdxDelta(a: Int, b: Int): Int {
+            if (a < 0 || b < 0) return 0
             val diff = a - b
             return when {
                 diff < -(1 shl 7) -> diff + (1 shl 8)

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -77,7 +77,7 @@ class Vp8Packet private constructor (
 
     var TL0PICIDX: Int by Delegates.observable(TL0PICIDX ?: DePacketizer.VP8PayloadDescriptor.getTL0PICIDX(buffer, payloadOffset, payloadLength)) {
         _, _, newValue ->
-            if (!DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
+            if (newValue != -1 && !DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
                     buffer, payloadOffset, payloadLength, newValue)) {
                 logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
             }


### PR DESCRIPTION
This is needed for a workaround to the Firefox 75 bug https://bugzilla.mozilla.org/show_bug.cgi?id=1628851 .