### PR TITLE
Bouncy Castle 1.65 instead of 1.61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <kotlin.version>1.3.61</kotlin.version>
         <kotlintest.version>3.4.2</kotlintest.version>
         <junit.version>5.2.0</junit.version>
-        <bouncycastle.version>1.61</bouncycastle.version>
+        <bouncycastle.version>1.65</bouncycastle.version>
         <jitsi.utils.version>1.0-44-gba9ad73</jitsi.utils.version>
         <ktlint.skip>false</ktlint.skip>
     </properties>


### PR DESCRIPTION
Bouncy Castle 1.65 instead of 1.61: https://www.bouncycastle.org/releasenotes.html
- http://www.bouncycastle.org/latest_releases.html

Note:
- In official source: https://polydistortion.net/bc/download/
Packages have not the "." in version.

- In maven.org:
Packages have "." in version.

CVEs: https://www.cvedetails.com/vulnerability-list/vendor_id-7637/Bouncycastle.html