### PR TITLE
Add config to lock down the REST API for PCAP capture.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -85,7 +85,7 @@ class PcapWriterConfig {
             class PcapEnabledProperty : SimpleProperty<Boolean>(
                 newConfigAttributes {
                     readOnce()
-                    name("jmt.pcap.enabled")
+                    name("jmt.debug.pcap.enabled")
                 }
             )
             private val pcapEnabledProperty =

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jitsi.config.newConfigAttributes
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.FeatureToggleEvent
 import org.jitsi.nlj.Features
@@ -21,7 +22,9 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.Node
 import org.jitsi.nlj.transform.node.ObserverNode
 import org.jitsi.nlj.transform.node.PcapWriter
+import org.jitsi.utils.config.SimpleProperty
 import org.jitsi.utils.logging2.Logger
+import java.lang.IllegalStateException
 import java.util.Date
 
 class ToggleablePcapWriter(
@@ -33,6 +36,9 @@ class ToggleablePcapWriter(
     private val pcapLock = Any()
 
     fun enable() {
+        if (!PcapWriterConfig.Config.pcapEnabled()) {
+            throw IllegalStateException("PCAP capture is disabled in configuration")
+        }
         synchronized(pcapLock) {
             if (pcapWriter == null) {
                 pcapWriter = PcapWriter(parentLogger, "/tmp/$prefix-${Date().toInstant()}.pcap")
@@ -69,5 +75,24 @@ class ToggleablePcapWriter(
         }
 
         override fun trace(f: () -> Unit) = f.invoke()
+    }
+}
+
+class PcapWriterConfig {
+    class Config {
+        companion object {
+
+            class PcapEnabledProperty : SimpleProperty<Boolean>(
+                newConfigAttributes {
+                    readOnce()
+                    name("jmt.pcap.enabled")
+                }
+            )
+            private val pcapEnabledProperty =
+                PcapEnabledProperty()
+
+            @JvmStatic
+            fun pcapEnabled(): Boolean = pcapEnabledProperty.value
+        }
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -46,4 +46,10 @@ jmt {
         queue-size=1024
       }
   }
+
+  pcap {
+    # Whether to permit the API to dynamically enable the capture of
+    # unencrypted PCAP files of media traffic.
+    enabled=false
+  }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -47,9 +47,11 @@ jmt {
       }
   }
 
-  pcap {
-    # Whether to permit the API to dynamically enable the capture of
-    # unencrypted PCAP files of media traffic.
-    enabled=false
+  debug {
+    pcap {
+      # Whether to permit the API to dynamically enable the capture of
+      # unencrypted PCAP files of media traffic.
+      enabled=false
+    }
   }
 }


### PR DESCRIPTION
This makes sure that the PCAP capture REST API won't work unless it's explicitly enabled in the jvb config.