### PR TITLE
Avoid ObservableProperty used with primitive types in Vp8Packet.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -22,7 +22,6 @@ import org.jitsi.utils.logging2.cwarn
 import org.jitsi.rtp.extensions.bytearray.hashCodeOfSegment
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi_modified.impl.neomedia.codec.video.vp8.DePacketizer
-import kotlin.properties.Delegates
 
 /**
  * If this [Vp8Packet] instance is being created via a clone,
@@ -75,16 +74,20 @@ class Vp8Packet private constructor (
 
     val hasTL0PICIDX = DePacketizer.VP8PayloadDescriptor.hasTL0PICIDX(buffer, payloadOffset, payloadLength)
 
-    var TL0PICIDX: Int by Delegates.observable(TL0PICIDX ?: DePacketizer.VP8PayloadDescriptor.getTL0PICIDX(buffer, payloadOffset, payloadLength)) {
-        _, _, newValue ->
+    private var _TL0PICIDX = TL0PICIDX ?: DePacketizer.VP8PayloadDescriptor.getTL0PICIDX(buffer, payloadOffset, payloadLength)
+    var TL0PICIDX: Int
+        get() = _TL0PICIDX
+        set(newValue) {
             if (newValue != -1 && !DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
                     buffer, payloadOffset, payloadLength, newValue)) {
                 logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
             }
         }
 
-    var pictureId: Int by Delegates.observable(pictureId ?: DePacketizer.VP8PayloadDescriptor.getPictureId(buffer, payloadOffset)) {
-        _, _, newValue ->
+    private var _pictureId = pictureId ?: DePacketizer.VP8PayloadDescriptor.getPictureId(buffer, payloadOffset)
+    var pictureId: Int
+        get() = _pictureId
+        set(newValue) {
             if (!DePacketizer.VP8PayloadDescriptor.setExtendedPictureId(
                     buffer, payloadOffset, payloadLength, newValue)) {
                 logger.cwarn { "Failed to set the picture id of a VP8 packet." }

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -78,13 +78,10 @@ class Vp8Packet private constructor (
     var TL0PICIDX: Int
         get() = _TL0PICIDX
         set(newValue) {
-            if (newValue != 1) {
-                if (DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
-                        buffer, payloadOffset, payloadLength, newValue)) {
-                    _TL0PICIDX = newValue
-                } else {
-                    logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
-                }
+            _TL0PICIDX = newValue
+            if (newValue != 1 && !DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
+                    buffer, payloadOffset, payloadLength, newValue)) {
+                logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
             }
         }
 
@@ -92,10 +89,9 @@ class Vp8Packet private constructor (
     var pictureId: Int
         get() = _pictureId
         set(newValue) {
-            if (DePacketizer.VP8PayloadDescriptor.setExtendedPictureId(
+            _pictureId = newValue
+            if (!DePacketizer.VP8PayloadDescriptor.setExtendedPictureId(
                     buffer, payloadOffset, payloadLength, newValue)) {
-                _pictureId = newValue
-            } else {
                 logger.cwarn { "Failed to set the picture id of a VP8 packet." }
             }
         }

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -79,7 +79,7 @@ class Vp8Packet private constructor (
         get() = _TL0PICIDX
         set(newValue) {
             _TL0PICIDX = newValue
-            if (newValue != 1 && !DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
+            if (newValue != -1 && !DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
                     buffer, payloadOffset, payloadLength, newValue)) {
                 logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
             }

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -78,9 +78,13 @@ class Vp8Packet private constructor (
     var TL0PICIDX: Int
         get() = _TL0PICIDX
         set(newValue) {
-            if (newValue != -1 && !DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
-                    buffer, payloadOffset, payloadLength, newValue)) {
-                logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
+            if (newValue != 1) {
+                if (DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
+                        buffer, payloadOffset, payloadLength, newValue)) {
+                    _TL0PICIDX = newValue
+                } else {
+                    logger.cwarn { "Failed to set the TL0PICIDX of a VP8 packet." }
+                }
             }
         }
 
@@ -88,8 +92,10 @@ class Vp8Packet private constructor (
     var pictureId: Int
         get() = _pictureId
         set(newValue) {
-            if (!DePacketizer.VP8PayloadDescriptor.setExtendedPictureId(
+            if (DePacketizer.VP8PayloadDescriptor.setExtendedPictureId(
                     buffer, payloadOffset, payloadLength, newValue)) {
+                _pictureId = newValue
+            } else {
                 logger.cwarn { "Failed to set the picture id of a VP8 packet." }
             }
         }


### PR DESCRIPTION
This PR obsoletes https://github.com/jitsi/jitsi-media-transform/pull/257.

With this PR there will be no `java.lang.Integer` boxed and put on heap from usage in `Vp8Packet`.
This also eliminates an extra object for property itself.
This PR results in:
1. Enhanced data locality due to `Int` is now stored in object itself;
2. Reduces number of temporary objects in heap, eliminating `java.lang.Integer` and `kotlin.properties.ObsevableProperty` and hence helping garbage collector by not producing garbage;
3. Reduces memory usage due to reducing number of objects in heap:
   - with this PR `2` `Int` fields are only consume `8` bytes, 
   - before this PR `1` instance of `java.lang.Integer` consumed `20` bytes, `1` instance of `ObservableProperty` consumed `48` bytes, resulting in `(48 + 20) * 2 = 136 bytes` for `2` fields in packet. 

Here is object dump in runtime before this PR:
![image](https://user-images.githubusercontent.com/385639/79974730-84743c80-84a2-11ea-90d0-325a613a8f76.png)

Here is object dump in runtime with this PR applied:
![image](https://user-images.githubusercontent.com/385639/79974906-c2716080-84a2-11ea-851f-77a3d028f6cd.png)

The object graph is reduced because of different byte code was generated.

Initial code (decompiled to `Java` to remove `Kotlin`s syntactic sugar):
```
public final class Vp8Packet extends ParsedVideoPacket {
   ...
   @NotNull
   private final ReadWriteProperty TL0PICIDX$delegate;
   @NotNull
   private final ReadWriteProperty pictureId$delegate;
   ...

   private Vp8Packet(...) {
      ...
      Delegates var10 = Delegates.INSTANCE;
      Object initialValue$iv = TL0PICIDX != null ? TL0PICIDX : VP8PayloadDescriptor.getTL0PICIDX(buffer, this.getPayloadOffset(), this.getPayloadLength());
      int $i$f$observable = false;
      ReadWriteProperty var14 = (ReadWriteProperty)(new Vp8Packet$$special$$inlined$observable$1(initialValue$iv, initialValue$iv, this, buffer));
      this.TL0PICIDX$delegate = var14;
      var10 = Delegates.INSTANCE;
      initialValue$iv = pictureId != null ? pictureId : VP8PayloadDescriptor.getPictureId(buffer, this.getPayloadOffset());
      $i$f$observable = false;
      var14 = (ReadWriteProperty)(new Vp8Packet$$special$$inlined$observable$2(initialValue$iv, initialValue$iv, this, buffer));
      this.pictureId$delegate = var14;
      ...
   }
   ...
}
```

With this PR (decompiled):
```
public final class Vp8Packet extends ParsedVideoPacket {
  ...
  private int _TL0PICIDX;
  
  private int _pictureId;
  ...

  private Vp8Packet(...) {
    ...
    this._TL0PICIDX = (TL0PICIDX != null) ? TL0PICIDX.intValue() : DePacketizer.VP8PayloadDescriptor.getTL0PICIDX(buffer, getPayloadOffset(), getPayloadLength());
    this._pictureId = (pictureId != null) ? pictureId.intValue() : DePacketizer.VP8PayloadDescriptor.getPictureId(buffer, getPayloadOffset());
    ...
  }
  ...
}
```

