### PR TITLE
Replace `Pair<Long, Long>` with non-generic class.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -37,8 +37,7 @@ import org.jitsi.utils.logging2.Logger
  */
 private const val MAX_SR_TIMESTAMP_HISTORY = 200
 
-private typealias SsrcAndTimestamp = Pair<Long, Long>
-
+private data class SsrcAndTimestamp(val ssrc: Long, val timestamp: Long)
 /**
  * Tracks stats which are not necessarily tied to send or receive but the endpoint overall
  */
@@ -93,7 +92,7 @@ class EndpointConnectionStats(
         when (packet) {
             is RtcpSrPacket -> {
                 logger.cdebug { "Tracking sent SR packet with compacted timestamp ${packet.senderInfo.compactedNtpTimestamp}" }
-                srSentTimes[Pair(packet.senderSsrc, packet.senderInfo.compactedNtpTimestamp)] = clock.instant()
+                srSentTimes[SsrcAndTimestamp(packet.senderSsrc, packet.senderInfo.compactedNtpTimestamp)] = clock.instant()
             }
         }
     }


### PR DESCRIPTION
This is another small step toward reducing allocation rate of temporary `java.lang.Long` objects on a heap.

Object layout before this change - object graph size for `Pair<Long, Long>` is `80` bytes:
 
![image](https://user-images.githubusercontent.com/385639/80115291-3f790480-858d-11ea-9ee4-49be9c778020.png)

Object layout with this change - object graph size for `SsrcAndTimestamp` is `32` bytes:
![image](https://user-images.githubusercontent.com/385639/80117068-65070d80-858f-11ea-92ad-afb7a6342cb8.png)
