### PR TITLE
Clean up for layer IDs

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
@@ -128,18 +128,7 @@ class MediaSourceDesc
         }
         val encodingId = videoRtpPacket.getEncodingId()
         val desc = layersById[encodingId]
-        if (desc != null) {
-            return desc
-        }
-        /* ??? Does this part actually get used?
-         * I think it won't, because ssrc should always be
-         * the encoding's primary SSRC by this point. */
-        for (encoding in rtpEncodings) {
-            if (encoding.matches(videoRtpPacket.ssrc)) {
-                return encoding.findRtpLayerDesc(videoRtpPacket)
-            }
-        }
-        return null
+        return desc
     }
 
     @Synchronized

--- a/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
@@ -17,7 +17,6 @@ package org.jitsi.nlj
 
 import org.jitsi.nlj.rtp.SsrcAssociationType
 import org.jitsi.nlj.rtp.VideoRtpPacket
-import org.jitsi.nlj.rtp.codec.vp8.Vp8Packet
 import org.jitsi.nlj.stats.NodeStatsBlock
 
 /**
@@ -130,21 +129,5 @@ constructor(
 }
 
 fun VideoRtpPacket.getEncodingId(): Long {
-    val layerId =
-        if (this is Vp8Packet) {
-            // note(george) we've observed that a client may announce but not
-            // send simulcast (it is not clear atm who's to blame for this
-            // "bug", chrome or our client code). In any case, when this happens
-            // we "pretend" that the encoding of the packet is the base temporal
-            // layer of the encoding.
-            val tid = temporalLayerIndex
-            if (tid >= 0) {
-                tid
-            } else {
-                0
-            }
-        } else {
-            0
-        }
-    return RtpEncodingDesc.calcEncodingId(ssrc, layerId)
+    return RtpEncodingDesc.calcEncodingId(ssrc, this.layerId)
 }

--- a/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
@@ -100,22 +100,6 @@ constructor(
             "layers=${layers.joinToString(separator = "\n    ")}"
     }
 
-    fun findRtpLayerDesc(packet: VideoRtpPacket): RtpLayerDesc? =
-        layers.find { it.matches(packet) }
-
-    fun matches(packet: VideoRtpPacket): Boolean {
-        if (!matches(packet.ssrc)) {
-            return false
-        } else if (layers.isEmpty()) {
-            return true // ???
-        } else for (layer in layers) {
-            if (layer.matches(packet)) {
-                return true
-            }
-        }
-        return false
-    }
-
     /**
      * Gets a boolean indicating whether or not the SSRC specified in the
      * arguments matches this encoding or not.

--- a/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -15,8 +15,6 @@
  */
 package org.jitsi.nlj
 
-import org.jitsi.nlj.rtp.VideoRtpPacket
-import org.jitsi.nlj.rtp.codec.vp8.Vp8Packet
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.utils.stats.RateStatistics
 
@@ -88,23 +86,6 @@ constructor(
         return "subjective_quality=" + index +
             ",temporal_id=" + tid +
             ",spatial_id=" + sid
-    }
-
-    fun matches(packet: VideoRtpPacket): Boolean {
-        return if (tid == -1 && sid == -1) {
-            true
-        } else if (packet is Vp8Packet) {
-            // NOTE(brian): the spatial layer index of an encoding is only currently used for in-band spatial
-            // scalability (a la vp9), so it isn't used for anything we're currently supporting (and is
-            // codec-specific, so should probably be implemented in another way anyhow) so for now we don't
-            // check that here (note, though, that the spatial layer index in a packet is currently set as of
-            // the time of this writing and is from the perspective of a logical spatial index, i.e. the lowest sim
-            // stream (180p) has spatial index 0, 360p has 1, 720p has 2.
-            val vp8PacketTid = packet.temporalLayerIndex
-            tid == vp8PacketTid || vp8PacketTid == -1 && tid == 0
-        } else {
-            true
-        }
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
@@ -40,6 +40,8 @@ open class VideoRtpPacket protected constructor(
     /** The index of this packet relative to its source's RtpLayers. */
     var qualityIndex: Int = qualityIndex ?: -1
 
+    open val layerId = 0
+
     override fun clone(): VideoRtpPacket {
         return VideoRtpPacket(
             cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.rtp.codec.vp8
 
+import org.jitsi.nlj.RtpLayerDesc
 import org.jitsi.nlj.codec.vp8.Vp8Utils
 import org.jitsi.nlj.rtp.ParsedVideoPacket
 import org.jitsi.utils.logging2.cwarn
@@ -97,6 +98,10 @@ class Vp8Packet private constructor (
         }
 
     val temporalLayerIndex: Int = Vp8Utils.getTemporalLayerIdOfFrame(this)
+
+    override val layerId: Int
+        get() = if (hasTemporalLayerIndex) RtpLayerDesc.getIndex(0, 0, temporalLayerIndex) else 0
+
     /**
      * This is currently used as an overall spatial index, not an in-band spatial quality index a la vp9.  That is,
      * this index will correspond to an overall simulcast layer index across multiple simulcast stream.  e.g.

--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -100,7 +100,7 @@ class Vp8Packet private constructor (
     val temporalLayerIndex: Int = Vp8Utils.getTemporalLayerIdOfFrame(this)
 
     override val layerId: Int
-        get() = if (hasTemporalLayerIndex) RtpLayerDesc.getIndex(0, 0, temporalLayerIndex) else 0
+        get() = if (hasTemporalLayerIndex) RtpLayerDesc.getIndex(0, 0, temporalLayerIndex) else super.layerId
 
     /**
      * This is currently used as an overall spatial index, not an in-band spatial quality index a la vp9.  That is,


### PR DESCRIPTION
I think this also makes sure that packet's 'qualityId' values get set to their proper temporal layers.