### PR TITLE
Log "vp8 packet does not have picture id", etc, only when state changes.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -21,9 +21,9 @@ import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.rtp.codec.vp8.Vp8Packet
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ModifierNode
+import org.jitsi.nlj.util.StateChangeLogger
 import org.jitsi.rtp.extensions.toHex
 import org.jitsi.utils.logging2.cdebug
-import org.jitsi.utils.logging2.cinfo
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 
@@ -44,6 +44,10 @@ class Vp8Parser(
     // Stats
     private var numKeyframes: Int = 0
 
+    private val pictureIdState = StateChangeLogger("picture id", logger)
+    private val extendedPictureIdState = StateChangeLogger("extended picture ID", logger)
+    private val tl0PicIdxWithoutTidState = StateChangeLogger("TL0PICIDX without TID", logger)
+
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket
         if (videoRtpPacket is Vp8Packet) {
@@ -60,14 +64,14 @@ class Vp8Parser(
                 numKeyframes++
             }
 
-            if (!videoRtpPacket.hasPictureId) {
-                logger.cinfo { "Packet $videoRtpPacket does not have picture ID.  Packet data: ${videoRtpPacket.toHex(80)}" }
-            } else if (!videoRtpPacket.hasExtendedPictureId) {
-                logger.cinfo { "Packet $videoRtpPacket has 7-bit (short) picture ID.  Packet data: ${videoRtpPacket.toHex(80)}" }
+            pictureIdState.setState(videoRtpPacket.hasPictureId, videoRtpPacket) {
+                "Packet Data: ${videoRtpPacket.toHex(80)}"
             }
-
-            if (videoRtpPacket.hasTemporalLayerIndex && !videoRtpPacket.hasTL0PICIDX) {
-                logger.cinfo { "Packet $videoRtpPacket has TID but does not have TL0PICIDX.  Packet data: ${videoRtpPacket.toHex(80)}" }
+            extendedPictureIdState.setState(videoRtpPacket.hasExtendedPictureId, videoRtpPacket) {
+                "Packet Data: ${videoRtpPacket.toHex(80)}"
+            }
+            tl0PicIdxWithoutTidState.setState(videoRtpPacket.hasTL0PICIDX && !videoRtpPacket.hasTemporalLayerIndex, videoRtpPacket) {
+                "Packet Data: ${videoRtpPacket.toHex(80)}"
             }
         }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -44,9 +44,9 @@ class Vp8Parser(
     // Stats
     private var numKeyframes: Int = 0
 
-    private val pictureIdState = StateChangeLogger("picture id", logger)
-    private val extendedPictureIdState = StateChangeLogger("extended picture ID", logger)
-    private val tidWithoutTl0PicIdxState = StateChangeLogger("TID without TL0PICIDX", logger)
+    private val pictureIdState = StateChangeLogger("missing picture id", logger)
+    private val extendedPictureIdState = StateChangeLogger("missing extended picture ID", logger)
+    private val tidWithoutTl0PicIdxState = StateChangeLogger("TID with missing TL0PICIDX", logger)
 
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -46,7 +46,7 @@ class Vp8Parser(
 
     private val pictureIdState = StateChangeLogger("picture id", logger)
     private val extendedPictureIdState = StateChangeLogger("extended picture ID", logger)
-    private val tl0PicIdxWithoutTidState = StateChangeLogger("TL0PICIDX without TID", logger)
+    private val tl0PicIdxWithoutTidState = StateChangeLogger("TID without TL0PICIDX", logger)
 
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket
@@ -70,7 +70,7 @@ class Vp8Parser(
             extendedPictureIdState.setState(videoRtpPacket.hasExtendedPictureId, videoRtpPacket) {
                 "Packet Data: ${videoRtpPacket.toHex(80)}"
             }
-            tl0PicIdxWithoutTidState.setState(videoRtpPacket.hasTL0PICIDX && !videoRtpPacket.hasTemporalLayerIndex, videoRtpPacket) {
+            tl0PicIdxWithoutTidState.setState(videoRtpPacket.hasTL0PICIDX || !videoRtpPacket.hasTemporalLayerIndex, videoRtpPacket) {
                 "Packet Data: ${videoRtpPacket.toHex(80)}"
             }
         }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/Vp8Parser.kt
@@ -46,7 +46,7 @@ class Vp8Parser(
 
     private val pictureIdState = StateChangeLogger("picture id", logger)
     private val extendedPictureIdState = StateChangeLogger("extended picture ID", logger)
-    private val tl0PicIdxWithoutTidState = StateChangeLogger("TID without TL0PICIDX", logger)
+    private val tidWithoutTl0PicIdxState = StateChangeLogger("TID without TL0PICIDX", logger)
 
     override fun modify(packetInfo: PacketInfo): PacketInfo {
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket
@@ -70,7 +70,7 @@ class Vp8Parser(
             extendedPictureIdState.setState(videoRtpPacket.hasExtendedPictureId, videoRtpPacket) {
                 "Packet Data: ${videoRtpPacket.toHex(80)}"
             }
-            tl0PicIdxWithoutTidState.setState(videoRtpPacket.hasTL0PICIDX || !videoRtpPacket.hasTemporalLayerIndex, videoRtpPacket) {
+            tidWithoutTl0PicIdxState.setState(videoRtpPacket.hasTL0PICIDX || !videoRtpPacket.hasTemporalLayerIndex, videoRtpPacket) {
                 "Packet Data: ${videoRtpPacket.toHex(80)}"
             }
         }

--- a/src/main/kotlin/org/jitsi/nlj/util/StateChangeLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StateChangeLogger.kt
@@ -1,0 +1,26 @@
+package org.jitsi.nlj.util
+
+import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.cinfo
+
+/**
+ * Class that logs when state first becomes false, or changes from false to true,
+ * without logging on every packet.
+ */
+class StateChangeLogger(
+    val desc: String,
+    val logger: Logger
+) {
+    var state: Boolean? = null
+
+    fun setState(newState: Boolean, instance: Any, instanceDesc: () -> String) {
+        if (state != newState) {
+            if (newState == false) {
+                logger.cinfo { "Packet $instance does not have $desc.  ${instanceDesc()}" }
+            } else if (state != null) {
+                logger.cinfo { "Packet $instance has $desc when source previously did not.  ${instanceDesc()}" }
+            }
+            state = newState
+        }
+    }
+}

--- a/src/main/kotlin/org/jitsi/nlj/util/StateChangeLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StateChangeLogger.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jitsi.nlj.util
 
 import org.jitsi.utils.logging2.Logger

--- a/src/main/kotlin/org/jitsi/nlj/util/StateChangeLogger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StateChangeLogger.kt
@@ -32,9 +32,9 @@ class StateChangeLogger(
     fun setState(newState: Boolean, instance: Any, instanceDesc: () -> String) {
         if (state != newState) {
             if (newState == false) {
-                logger.cinfo { "Packet $instance does not have $desc.  ${instanceDesc()}" }
+                logger.cinfo { "Packet $instance has $desc.  ${instanceDesc()}" }
             } else if (state != null) {
-                logger.cinfo { "Packet $instance has $desc when source previously did not.  ${instanceDesc()}" }
+                logger.cinfo { "Packet $instance source no longer has $desc.  ${instanceDesc()}" }
             }
             state = newState
         }


### PR DESCRIPTION
Rather than on every such packet.