### PR TITLE
Upgrade kotlintest->kotest, other dep updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.71</kotlin.version>
-        <kotlintest.version>3.4.2</kotlintest.version>
+        <kotest.version>4.1.3</kotest.version>
         <junit.version>5.2.0</junit.version>
         <bouncycastle.version>1.65</bouncycastle.version>
         <jitsi.utils.version>1.0-57-g502cdeb</jitsi.utils.version>
@@ -105,15 +105,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-runner-junit5</artifactId>
-            <version>${kotlintest.version}</version>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-junit5-jvm</artifactId>
+            <version>${kotest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-property-jvm</artifactId>
+            <version>${kotest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-metaconfig</artifactId>
-            <version>ab50680335</version>
+            <version>c3d8c51747</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <kotlintest.version>3.4.2</kotlintest.version>
         <junit.version>5.2.0</junit.version>
         <bouncycastle.version>1.65</bouncycastle.version>
-        <jitsi.utils.version>1.0-47-gdb30505</jitsi.utils.version>
+        <jitsi.utils.version>1.0-57-g502cdeb</jitsi.utils.version>
         <ktlint.skip>false</ktlint.skip>
         <spotbugs.version>4.0.6</spotbugs.version>
         <jicoco.version>1.1-39-g6b2d353</jicoco.version>

--- a/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
@@ -19,13 +19,13 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
 import org.jitsi.nlj.transform.node.incoming.IncomingSsrcStats
 import org.jitsi.nlj.transform.node.incoming.IncomingStatisticsTracker
-import org.jitsi.nlj.util.milliseconds
 import org.jitsi.nlj.util.schedule
 import org.jitsi.rtp.rtcp.CompoundRtcpPacket
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtcp.RtcpReportBlock
 import org.jitsi.rtp.rtcp.RtcpRrPacketBuilder
 import org.jitsi.rtp.rtcp.RtcpSrPacket
+import org.jitsi.utils.ms
 
 /**
  * Information about a sender that is used in the generation of RTCP report blocks.  NOTE that this does NOT correspond
@@ -125,6 +125,6 @@ class RtcpRrGenerator(
         /**
          * The interval at which RRs and REMBs will be sent.
          */
-        val reportingInterval = 500.milliseconds()
+        val reportingInterval = 500.ms
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -31,6 +31,7 @@ import org.jitsi.rtp.rtcp.RtcpRrPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
 import org.jitsi.utils.LRUCache
 import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.secs
 
 /**
  * The maximum number of SR packets and their timestamps to save.
@@ -113,7 +114,7 @@ class EndpointConnectionStats(
             // in nanoseconds
             val remoteProcessingDelay = Duration.ofNanos((reportBlock.delaySinceLastSr / .000065536).toLong())
             rtt = (Duration.between(srSentTime, receivedTime) - remoteProcessingDelay).toDoubleMillis()
-            if (rtt > Duration.ofSeconds(7).toMillis()) {
+            if (rtt > 7.secs.toMillis()) {
                 logger.warn("Suspiciously high rtt value: $rtt ms, remote processing delay was " +
                     "$remoteProcessingDelay (${reportBlock.delaySinceLastSr}), srSentTime was $srSentTime, " +
                     "received time was $receivedTime")

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
@@ -30,6 +30,7 @@ import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.utils.stats.RateStatistics
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.RtpLayerDesc
+import org.jitsi.utils.secs
 import java.time.Clock
 import java.time.Duration
 
@@ -122,6 +123,6 @@ open class BitrateCalculator(
         /**
          * The initial period in which we consider the stream active regardless of packet rate.
          */
-        val GRACE_PERIOD = Duration.ofSeconds(10)
+        val GRACE_PERIOD = 10.secs
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -27,7 +27,6 @@ import org.jitsi.nlj.util.NEVER
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.Rfc3711IndexTracker
 import org.jitsi.utils.logging2.cdebug
-import org.jitsi.nlj.util.milliseconds
 import org.jitsi.utils.observableWhenChanged
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket
@@ -36,6 +35,7 @@ import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.TccHeaderExtension
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.utils.ms
 import org.jitsi.utils.stats.RateStatistics
 
 /**
@@ -172,8 +172,8 @@ class TccGeneratorNode(
         }
 
         val timeSinceLastTcc = Duration.between(lastTccSentTime, now)
-        return timeSinceLastTcc >= 100.milliseconds() ||
-            ((timeSinceLastTcc >= 20.milliseconds()) && currentPacketMarked)
+        return timeSinceLastTcc >= 100.ms ||
+            ((timeSinceLastTcc >= 20.ms) && currentPacketMarked)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/src/main/kotlin/org/jitsi/nlj/util/DurationExtensions.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/DurationExtensions.kt
@@ -2,15 +2,6 @@ package org.jitsi.nlj.util
 
 import java.time.Duration
 
-fun Int.milliseconds(): Duration = Duration.ofMillis(this.toLong())
-fun Int.ms(): Duration = Duration.ofMillis(this.toLong())
-
-operator fun Duration.times(x: Int): Duration = Duration.ofNanos(toNanos() * x)
-operator fun Duration.div(other: Duration): Double = toNanos().toDouble() / other.toNanos()
-
-fun Int.minutes(): Duration = Duration.ofMinutes(this.toLong())
-fun Int.mins(): Duration = Duration.ofMinutes(this.toLong())
-
 fun Duration.toDoubleMillis(): Double {
     val sec = this.seconds
     val nano = this.nano

--- a/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -16,8 +16,8 @@
 
 package org.jitsi.nlj
 
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.utils.stats.RateStatistics
 
 class MediaSourceDescTest : ShouldSpec() {
@@ -26,7 +26,7 @@ class MediaSourceDescTest : ShouldSpec() {
         val source = createSource(ssrcs,
             1, 3, "Fake owner")
 
-        "Source properties should be correct" {
+        context("Source properties should be correct") {
             source.owner shouldBe "Fake owner"
             source.rtpEncodings.size shouldBe 3
 
@@ -37,7 +37,7 @@ class MediaSourceDescTest : ShouldSpec() {
             source.matches(0xdeadbeef) shouldBe true
         }
 
-        "Encoding and layer properties should be correct" {
+        context("Encoding and layer properties should be correct") {
             for (i in source.rtpEncodings.indices) {
                 val e = source.rtpEncodings[i]
                 e.primarySSRC shouldBe ssrcs[i]
@@ -59,7 +59,7 @@ class MediaSourceDescTest : ShouldSpec() {
             }
         }
 
-        "Layer bitrates should be correct" {
+        context("Layer bitrates should be correct") {
             val t = 0L // Doesn't actually matter for fake rate statistics
 
             /* Rate from layer 0 */

--- a/src/test/kotlin/org/jitsi/nlj/MediaSourcesTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/MediaSourcesTest.kt
@@ -15,9 +15,9 @@
  */
 package org.jitsi.nlj
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 
 class MediaSourcesTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
@@ -31,7 +31,7 @@ class MediaSourcesTest : ShouldSpec() {
         val sourceC = createSource(3000, 3001)
 
         var changed = mediaSources.setMediaSources(arrayOf(sourceA, sourceB))
-        "Setting initially  must signal a change." {
+        context("Setting initially  must signal a change.") {
             changed shouldBe true
 
             val newSources = mediaSources.getMediaSources()
@@ -39,7 +39,7 @@ class MediaSourcesTest : ShouldSpec() {
             newSources[1] shouldBe sourceB
         }
 
-        "Setting the same sources must not signal a change." {
+        context("Setting the same sources must not signal a change.") {
             changed = mediaSources.setMediaSources(arrayOf(sourceA, sourceB))
             changed shouldBe false
 
@@ -48,7 +48,7 @@ class MediaSourcesTest : ShouldSpec() {
             newSources[1] shouldBe sourceB
         }
 
-        "Setting matching sources must not signal a change, or change the saved sources" {
+        context("Setting matching sources must not signal a change, or change the saved sources") {
             changed = mediaSources.setMediaSources(arrayOf(sourceA2, sourceB2))
             changed shouldBe false
 
@@ -57,7 +57,7 @@ class MediaSourcesTest : ShouldSpec() {
             newSources[1] shouldBe sourceB
         }
 
-        "Adding a new source must signal a change, but not change the previous sources" {
+        context("Adding a new source must signal a change, but not change the previous sources") {
             changed = mediaSources.setMediaSources(arrayOf(sourceA2, sourceB2, sourceC))
             changed shouldBe true
 
@@ -67,7 +67,7 @@ class MediaSourcesTest : ShouldSpec() {
             newSources[2] shouldBe sourceC
         }
 
-        "Removing a source must signal a change, but not change the previous source" {
+        context("Removing a source must signal a change, but not change the previous source") {
             changed = mediaSources.setMediaSources(arrayOf(sourceA))
             changed shouldBe true
 
@@ -75,7 +75,7 @@ class MediaSourcesTest : ShouldSpec() {
             newSources[0] shouldBe sourceA
         }
 
-        "Adding and removing must signal a change, but not change the previous source" {
+        context("Adding and removing must signal a change, but not change the previous source") {
             changed = mediaSources.setMediaSources(arrayOf(sourceA2, sourceC))
             changed shouldBe true
 

--- a/src/test/kotlin/org/jitsi/nlj/codec/vp8/Vp8UtilsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/codec/vp8/Vp8UtilsTest.kt
@@ -16,17 +16,17 @@
 
 package org.jitsi.nlj.codec.vp8
 
-import io.kotlintest.data.forall
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
-import io.kotlintest.tables.row
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
 
 class Vp8UtilsTest : ShouldSpec() {
 
     init {
-        "getPicIdDelta" {
+        context("getPicIdDelta") {
             should("work correctly") {
-                forall(
+                forAll(
                     row(1, 10, -9),
                     row(10, 1, 9),
                     row(1, 32760, 9),
@@ -37,9 +37,9 @@ class Vp8UtilsTest : ShouldSpec() {
                 }
             }
         }
-        "applyPicIdDelta" {
+        context("applyPicIdDelta") {
             should("work correctly") {
-                forall(
+                forAll(
                     row(10, -9, 1),
                     row(1, 9, 10),
                     row(32760, 9, 1),
@@ -50,9 +50,9 @@ class Vp8UtilsTest : ShouldSpec() {
                 }
             }
         }
-        "getTl0PicIdxDelta" {
+        context("getTl0PicIdxDelta") {
             should("work correctly") {
-                forall(
+                forAll(
                     row(1, 10, -9),
                     row(10, 1, 9),
                     row(1, 250, 7),
@@ -63,9 +63,9 @@ class Vp8UtilsTest : ShouldSpec() {
                 }
             }
         }
-        "applyTl0PicIdxDelta" {
+        context("applyTl0PicIdxDelta") {
             should("work correctly") {
-                forall(
+                forAll(
                     row(10, -9, 1),
                     row(1, 9, 10),
                     row(250, 7, 1),

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -16,9 +16,9 @@
 
 package org.jitsi.nlj.dtls
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.transform.node.PcapWriter

--- a/src/test/kotlin/org/jitsi/nlj/format/PayloadTypeEncodingTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/format/PayloadTypeEncodingTest.kt
@@ -16,15 +16,15 @@
 
 package org.jitsi.nlj.format
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 
 internal class PayloadTypeEncodingTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     init {
-        "createFrom" {
+        context("createFrom") {
             should("be case insensitive") {
                 val encoding = PayloadTypeEncoding.createFrom("vp8")
                 val encoding2 = PayloadTypeEncoding.createFrom("vP8")

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/EndToEndHarness.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/EndToEndHarness.kt
@@ -16,13 +16,13 @@
 
 package org.jitsi.nlj.module_tests
 
-import java.time.Duration
-import java.util.concurrent.Executors
 import org.jitsi.nlj.PacketHandler
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.util.BufferPool
 import org.jitsi.nlj.util.safeShutdown
 import org.jitsi.test_utils.Pcaps
+import org.jitsi.utils.secs
+import java.util.concurrent.Executors
 
 /**
  * Read packets from a PCAP file and feed them through a receiver
@@ -89,8 +89,8 @@ fun main() {
 
     receiver.stop()
     sender.stop()
-    executor.safeShutdown(Duration.ofSeconds(10))
-    backgroundExecutor.safeShutdown(Duration.ofSeconds(10))
+    executor.safeShutdown(10.secs)
+    backgroundExecutor.safeShutdown(10.secs)
 
     println(receiver.getNodeStats().prettyPrint())
     println(sender.getNodeStats().prettyPrint())

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/RtpReceiverHarness.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/RtpReceiverHarness.kt
@@ -15,15 +15,15 @@
  */
 package org.jitsi.nlj.module_tests
 
-import java.time.Duration
-import java.util.concurrent.Executors
-import java.util.logging.Level
-import kotlin.system.measureTimeMillis
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpReceiver
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.util.safeShutdown
 import org.jitsi.test_utils.Pcaps
+import org.jitsi.utils.secs
+import java.util.concurrent.Executors
+import java.util.logging.Level
+import kotlin.system.measureTimeMillis
 
 /**
  * Feed media data from a PCAP file through N receivers.  This harness
@@ -65,8 +65,8 @@ fun main(args: Array<String>) {
     }
     println("took $time ms")
     receivers.forEach(RtpReceiver::stop)
-    executor.safeShutdown(Duration.ofSeconds(10))
-    backgroundExecutor.safeShutdown(Duration.ofSeconds(10))
+    executor.safeShutdown(10.secs)
+    backgroundExecutor.safeShutdown(10.secs)
 
     receivers.forEach { println(it.getNodeStats().prettyPrint()) }
 }

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/RtpReceiverNoNewBufferTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/RtpReceiverNoNewBufferTest.kt
@@ -16,13 +16,13 @@
 
 package org.jitsi.nlj.module_tests
 
-import java.time.Duration
-import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
 import org.jitsi.nlj.PacketHandler
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.util.safeShutdown
 import org.jitsi.test_utils.Pcaps
+import org.jitsi.utils.secs
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
 
 /**
  * Verify that the same buffer we feed into the receive pipeline is the one we get
@@ -75,8 +75,8 @@ fun main() {
     producer.run()
 
     receiver.stop()
-    executor.safeShutdown(Duration.ofSeconds(10))
-    backgroundExecutor.safeShutdown(Duration.ofSeconds(10))
+    executor.safeShutdown(10.secs)
+    backgroundExecutor.safeShutdown(10.secs)
 
     println("Num new arrays: $numNewArrays")
 }

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/RtpSenderHarness.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/RtpSenderHarness.kt
@@ -15,9 +15,6 @@
  */
 package org.jitsi.nlj.module_tests
 
-import java.time.Duration
-import java.util.concurrent.Executors
-import kotlin.system.measureTimeMillis
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpSender
 import org.jitsi.nlj.util.safeShutdown
@@ -25,6 +22,9 @@ import org.jitsi.rtp.extensions.looksLikeRtp
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.test_utils.Pcaps
+import org.jitsi.utils.secs
+import java.util.concurrent.Executors
+import kotlin.system.measureTimeMillis
 
 fun main(args: Array<String>) {
     val pcap = Pcaps.Outgoing.ONE_PARITICPANT_RTP_AND_RTCP_DECRYPTED
@@ -56,8 +56,8 @@ fun main(args: Array<String>) {
     }
     println("took $time ms")
     senders.forEach(RtpSender::stop)
-    senderExecutor.safeShutdown(Duration.ofSeconds(10))
-    backgroundExecutor.safeShutdown(Duration.ofSeconds(10))
+    senderExecutor.safeShutdown(10.secs)
+    backgroundExecutor.safeShutdown(10.secs)
 
     senders.forEach { println(it.getNodeStats().prettyPrint()) }
 }

--- a/src/test/kotlin/org/jitsi/nlj/rtcp/CompoundRtcpParserTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtcp/CompoundRtcpParserTest.kt
@@ -16,11 +16,11 @@
 
 package org.jitsi.nlj.rtcp
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.matchers.types.shouldBeInstanceOf
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.resources.node.onOutput
@@ -58,8 +58,8 @@ class CompoundRtcpParserTest : ShouldSpec() {
     ).build()
 
     init {
-        "A compound RTCP packet with invalid data" {
-            "at the beginning of the packet" {
+        context("A compound RTCP packet with invalid data") {
+            context("at the beginning of the packet") {
                 val packet = DummyPacket(invalidRtcpData)
                 val packetInfo = PacketInfo(packet)
                 should("drop the packet entirely") {
@@ -67,7 +67,7 @@ class CompoundRtcpParserTest : ShouldSpec() {
                     parser.processPacket(packetInfo)
                 }
             }
-            "after a valid packet" {
+            context("after a valid packet") {
                 val packet = DummyPacket(rtcpByeNoReason + invalidRtcpData)
                 val packetInfo = PacketInfo(packet)
                 should("drop the packet entirely") {
@@ -76,8 +76,8 @@ class CompoundRtcpParserTest : ShouldSpec() {
                 }
             }
         }
-        "A compound RTCP packet with an unsupported RTCP type" {
-            "at the beginning of the packet" {
+        context("A compound RTCP packet with an unsupported RTCP type") {
+            context("at the beginning of the packet") {
                 val packet = DummyPacket(unsupportedRtcpData)
                 val packetInfo = PacketInfo(packet)
                 should("parse it as UnsupportedRtcpPacket") {
@@ -90,7 +90,7 @@ class CompoundRtcpParserTest : ShouldSpec() {
                     parser.processPacket(packetInfo)
                 }
             }
-            "in between other supported RTCP packets" {
+            context("in between other supported RTCP packets") {
                 val packet = DummyPacket(rtcpByeNoReason + unsupportedRtcpData + rtcpByeNoReason)
                 val packetInfo = PacketInfo(packet)
                 should("parse it as UnsupportedRtcpPacket") {

--- a/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
@@ -16,14 +16,12 @@
 
 package org.jitsi.nlj.rtcp
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.collections.shouldBeEmpty
-import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.matchers.types.shouldBeInstanceOf
-import io.kotlintest.milliseconds
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.resources.logging.StdoutLogger
@@ -38,6 +36,8 @@ import org.jitsi.nlj.util.RtpExtensionHandler
 import org.jitsi.nlj.util.RtpPayloadTypesChangedHandler
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbFirPacket
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket
+import org.jitsi.utils.ms
+import org.jitsi.utils.secs
 
 class KeyframeRequesterTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
@@ -75,8 +75,8 @@ class KeyframeRequesterTest : ShouldSpec() {
     init {
         keyframeRequester.onOutput { sentKeyframeRequests.add(it) }
 
-        "requesting a keyframe" {
-            "without a specific SSRC" {
+        context("requesting a keyframe") {
+            context("without a specific SSRC") {
                 keyframeRequester.requestKeyframe()
                 should("result in a sent PLI request with the first video SSRC") {
                     sentKeyframeRequests shouldHaveSize 1
@@ -86,7 +86,7 @@ class KeyframeRequesterTest : ShouldSpec() {
                     packet.mediaSourceSsrc shouldBe 123L
                 }
             }
-            "when PLI is supported" {
+            context("when PLI is supported") {
                 keyframeRequester.requestKeyframe(123L)
                 should("result in a sent PLI request") {
                     sentKeyframeRequests shouldHaveSize 1
@@ -95,17 +95,17 @@ class KeyframeRequesterTest : ShouldSpec() {
                     packet as RtcpFbPliPacket
                     packet.mediaSourceSsrc shouldBe 123L
                 }
-                "and then requesting again" {
+                context("and then requesting again") {
                     sentKeyframeRequests.clear()
-                    "within the wait interval" {
-                        clock.elapse(10.milliseconds)
-                        "on the same SSRC" {
+                    context("within the wait interval") {
+                        clock.elapse(10.ms)
+                        context("on the same SSRC") {
                             keyframeRequester.requestKeyframe(123L)
                             should("not send anything") {
                                 sentKeyframeRequests.shouldBeEmpty()
                             }
                         }
-                        "on a different SSRC" {
+                        context("on a different SSRC") {
                             keyframeRequester.requestKeyframe(456L)
                             should("result in a sent PLI request") {
                                 sentKeyframeRequests shouldHaveSize 1
@@ -116,8 +116,8 @@ class KeyframeRequesterTest : ShouldSpec() {
                             }
                         }
                     }
-                    "after the wait interval has expired" {
-                        clock.elapse(1.seconds)
+                    context("after the wait interval has expired") {
+                        clock.elapse(1.secs)
                         keyframeRequester.requestKeyframe(123L)
                         should("result in a sent PLI request") {
                             sentKeyframeRequests shouldHaveSize 1
@@ -129,7 +129,7 @@ class KeyframeRequesterTest : ShouldSpec() {
                     }
                 }
             }
-            "when PLI isn't supported" {
+            context("when PLI isn't supported") {
                 streamInformationStore.supportsPli = false
                 keyframeRequester.requestKeyframe(123L)
                 should("result in a sent FIR request") {
@@ -140,7 +140,7 @@ class KeyframeRequesterTest : ShouldSpec() {
                     packet.mediaSenderSsrc shouldBe 123L
                 }
             }
-            "when neither PLI nor FIR is supported" {
+            context("when neither PLI nor FIR is supported") {
                 streamInformationStore.supportsFir = false
                 streamInformationStore.supportsPli = false
                 keyframeRequester.requestKeyframe(123L)

--- a/src/test/kotlin/org/jitsi/nlj/rtp/PaddingVideoPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/PaddingVideoPacketTest.kt
@@ -16,16 +16,16 @@
 
 package org.jitsi.nlj.rtp
 
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.util.BufferPool
 import org.jitsi.rtp.rtp.RtpHeader
 
 class PaddingVideoPacketTest : ShouldSpec() {
 
     init {
-        "Creating a padding packet" {
-            "from a buffer that previously held other data" {
+        context("Creating a padding packet") {
+            context("from a buffer that previously held other data") {
                 BufferPool.getBuffer = { size ->
                     // A buffer with bogus CSRC count and header ext length values
                     org.jitsi.rtp.extensions.bytearray.byteArrayOf(

--- a/src/test/kotlin/org/jitsi/nlj/rtp/RtpExtensionTypeTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/RtpExtensionTypeTest.kt
@@ -16,13 +16,13 @@
 
 package org.jitsi.nlj.rtp
 
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 
 class RtpExtensionTypeTest : ShouldSpec() {
 
     init {
-        "Creating an extension from a valid URI" {
+        context("Creating an extension from a valid URI") {
             should("work correctly") {
                 RtpExtensionType.createFromUri(RtpExtensionType.TRANSPORT_CC.uri) shouldBe
                     RtpExtensionType.TRANSPORT_CC

--- a/src/test/kotlin/org/jitsi/nlj/rtp/RtxPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/RtxPacketTest.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.nlj.rtp
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.should
 import java.nio.ByteBuffer
 import org.jitsi.nlj.test_utils.matchers.haveSameContentAs
 import org.jitsi.rtp.rtp.RtpPacket
@@ -50,12 +50,12 @@ class RtxPacketTest : ShouldSpec() {
     val rtpPacket = RtpPacket(header + payload)
 
     init {
-        "Getting the original sequence number" {
+        context("Getting the original sequence number") {
             should("work correctly") {
                 RtxPacket.getOriginalSequenceNumber(rtxPacket) shouldBe 57005
             }
         }
-        "Removing the original sequence number" {
+        context("Removing the original sequence number") {
             should("work correctly") {
                 RtxPacket.removeOriginalSequenceNumber(rtxPacket)
                 val newPayload =
@@ -63,7 +63,7 @@ class RtxPacketTest : ShouldSpec() {
                 newPayload should haveSameContentAs(ByteBuffer.wrap(payload))
             }
         }
-        "Adding an original sequence number" {
+        context("Adding an original sequence number") {
             RtxPacket.addOriginalSequenceNumber(rtpPacket)
             should("work correctly") {
                 RtxPacket.getOriginalSequenceNumber(rtpPacket) shouldBe 5807

--- a/src/test/kotlin/org/jitsi/nlj/rtp/TransportCcEngineTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/TransportCcEngineTest.kt
@@ -1,9 +1,9 @@
 package org.jitsi.nlj.rtp
 
 import com.nhaarman.mockitokotlin2.mock
-import io.kotlintest.IsolationMode
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.FunSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.test_utils.FakeClock

--- a/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
@@ -1,7 +1,7 @@
 package org.jitsi.nlj.rtp.bandwidthestimation
 
-import io.kotlintest.matchers.doubles.shouldBeBetween
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.doubles.shouldBeBetween
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -210,7 +210,7 @@ class BandwidthEstimationTest : ShouldSpec() {
     private val receiver: PacketReceiver = PacketReceiver(clock, estimator, ctx) { generator.rate = it }
 
     init {
-        "Running bandwidth estimation test" {
+        context("Running bandwidth estimation test") {
             should("work correctly") {
                 bottleneck.rate = bottleneckRate
                 generator.rate = estimator.getCurrentBw(clock.instant())

--- a/src/test/kotlin/org/jitsi/nlj/stats/DelayStatsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/stats/DelayStatsTest.kt
@@ -15,11 +15,11 @@
  */
 package org.jitsi.nlj.stats
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.types.shouldBeInstanceOf
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jitsi.nlj.util.OrderedJsonObject
 import java.lang.IllegalArgumentException
 
@@ -27,7 +27,7 @@ class DelayStatsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     init {
-        "adding stats" {
+        context("adding stats") {
             val delayStats = DelayStats(longArrayOf(2, 5, 200, 999))
 
             should("calculate the average correctly") {
@@ -79,7 +79,7 @@ class DelayStatsTest : ShouldSpec() {
             }
         }
 
-        "initializing with invalid thresholds should throw" {
+        context("initializing with invalid thresholds should throw") {
             shouldThrow<IllegalArgumentException> {
                 DelayStats(longArrayOf(2, 10, 5))
             }

--- a/src/test/kotlin/org/jitsi/nlj/stats/JitterStatsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/stats/JitterStatsTest.kt
@@ -16,11 +16,11 @@
 
 package org.jitsi.nlj.stats
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.doubles.plusOrMinus
-import io.kotlintest.matchers.withClue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.doubles.plusOrMinus
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.rtp.rtp.RtpPacket
 
@@ -73,7 +73,7 @@ class JitterStatsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     init {
-        "Jitter" {
+        context("Jitter") {
             val jitterStats = JitterStats()
             should("update correctly") {
                 // Handled separately since we want to verify the jitter at each

--- a/src/test/kotlin/org/jitsi/nlj/stats/PacketIOActivityTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/stats/PacketIOActivityTest.kt
@@ -16,12 +16,12 @@
 
 package org.jitsi.nlj.stats
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.minutes
-import io.kotlintest.seconds
-import io.kotlintest.specs.ShouldSpec
-import io.kotlintest.shouldBe
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
 import org.jitsi.nlj.test_utils.FakeClock
+import org.jitsi.utils.secs
+import java.time.Duration
 
 class PacketIOActivityTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
@@ -30,15 +30,15 @@ class PacketIOActivityTest : ShouldSpec() {
     private val clock: FakeClock = FakeClock()
 
     init {
-        "Last packet time values" {
-            clock.elapse(1.minutes)
+        context("Last packet time values") {
+            clock.elapse(Duration.ofMinutes(1))
             val oldTime = clock.instant()
-            clock.elapse(1.minutes)
+            clock.elapse(Duration.ofMinutes(1))
             val newTime = clock.instant()
             packetIoActivity.lastRtpPacketSentInstant = newTime
             packetIoActivity.lastRtpPacketReceivedInstant = newTime
             packetIoActivity.lastIceActivityInstant = newTime
-            "when setting an older time" {
+            context("when setting an older time") {
                 packetIoActivity.lastRtpPacketSentInstant = oldTime
                 packetIoActivity.lastRtpPacketReceivedInstant = oldTime
                 packetIoActivity.lastIceActivityInstant = oldTime
@@ -49,13 +49,13 @@ class PacketIOActivityTest : ShouldSpec() {
                 }
             }
         }
-        "lastOverallRtpActivity" {
+        context("lastOverallRtpActivity") {
             should("only reflect RTP packet time values") {
-                clock.elapse(30.seconds)
+                clock.elapse(30.secs)
                 val rtpSentTime = clock.instant()
-                clock.elapse(5.seconds)
+                clock.elapse(5.secs)
                 val rtpReceivedTime = clock.instant()
-                clock.elapse(10.seconds)
+                clock.elapse(10.secs)
                 val iceTime = clock.instant()
                 packetIoActivity.lastRtpPacketSentInstant = rtpSentTime
                 packetIoActivity.lastRtpPacketReceivedInstant = rtpReceivedTime
@@ -63,13 +63,13 @@ class PacketIOActivityTest : ShouldSpec() {
                 packetIoActivity.lastRtpActivityInstant shouldBe rtpReceivedTime
             }
         }
-        "lastOverallActivity" {
+        context("lastOverallActivity") {
             should("only reflect all packet time values") {
-                clock.elapse(30.seconds)
+                clock.elapse(30.secs)
                 val rtpSentTime = clock.instant()
-                clock.elapse(10.seconds)
+                clock.elapse(10.secs)
                 val iceTime = clock.instant()
-                clock.elapse(5.seconds)
+                clock.elapse(5.secs)
                 val rtpReceivedTime = clock.instant()
                 packetIoActivity.lastRtpPacketSentInstant = rtpSentTime
                 packetIoActivity.lastRtpPacketReceivedInstant = rtpReceivedTime

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/FakeSchedulerExecutorServiceTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/FakeSchedulerExecutorServiceTest.kt
@@ -1,36 +1,37 @@
 package org.jitsi.nlj.test_utils
 
 import com.nhaarman.mockitokotlin2.spy
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
-import java.time.Duration
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.utils.secs
 import java.util.concurrent.TimeUnit
 
 class FakeSchedulerExecutorServiceTest : ShouldSpec() {
-    override fun isInstancePerTest(): Boolean = true
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     init {
         val executor: FakeScheduledExecutorService = spy()
 
-        "Scheduling a recurring job" {
+        context("Scheduling a recurring job") {
             var numJobRuns = 0
             val handle = executor.scheduleAtFixedRate({
                 numJobRuns++
             }, 5, 5, TimeUnit.SECONDS)
-            "and then calling runOne" {
+            context("and then calling runOne") {
                 executor.runOne()
                 should("have run the job") {
                     numJobRuns shouldBe 1
                 }
-                "and then calling runOne again" {
+                context("and then calling runOne again") {
                     executor.runOne()
                     should("have run the job again") {
                         numJobRuns shouldBe 2
                     }
                 }
-                "and then cancelling the job" {
+                context("and then cancelling the job") {
                     handle.cancel(true)
-                    "and then calling runOne again" {
+                    context("and then calling runOne again") {
                         executor.runOne()
                         should("not have run the job again") {
                             numJobRuns shouldBe 1
@@ -38,22 +39,22 @@ class FakeSchedulerExecutorServiceTest : ShouldSpec() {
                     }
                 }
             }
-            "and elapsing time before it should run" {
-                executor.clock.elapse(Duration.ofSeconds(4))
+            context("and elapsing time before it should run") {
+                executor.clock.elapse(4.secs)
                 executor.run()
                 should("not have run the job") {
                     numJobRuns shouldBe 0
                 }
-                "and then elapsing past the scheduled time" {
-                    executor.clock.elapse(Duration.ofSeconds(3))
+                context("and then elapsing past the scheduled time") {
+                    executor.clock.elapse(3.secs)
                     executor.run()
                     should("have run the job") {
                         numJobRuns shouldBe 1
                     }
                 }
             }
-            "and elapsing the time past multiple runs" {
-                executor.clock.elapse(Duration.ofSeconds(10))
+            context("and elapsing the time past multiple runs") {
+                executor.clock.elapse(10.secs)
                 executor.run()
                 should("have run the job multiple times") {
                     numJobRuns shouldBe 2

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/RtpPacketGenerator.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/RtpPacketGenerator.kt
@@ -23,6 +23,7 @@ import org.jitsi.nlj.util.atRate
 import org.jitsi.nlj.util.howMuchCanISendAtRate
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.utils.div
+import org.jitsi.utils.secs
 import java.time.Duration
 
 class RtpPacketGenerator internal constructor(
@@ -53,7 +54,7 @@ class RtpPacketGenerator internal constructor(
         /**
          * The total duration over which packets will be generated.
          */
-        duration: Duration = Duration.ofSeconds(10),
+        duration: Duration = 10.secs,
         clock: FakeClock = FakeClock()
     ) : this(
         length = length,
@@ -74,7 +75,7 @@ class RtpPacketGenerator internal constructor(
         /**
          * The total duration over which packets will be generated.
          */
-        duration: Duration = Duration.ofSeconds(10),
+        duration: Duration = 10.secs,
         clock: FakeClock = FakeClock()
     ) : this(
         length = howMuchCanISendAtRate(targetBitrate).`in`(interval),

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/RtpPacketGenerator.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/RtpPacketGenerator.kt
@@ -20,9 +20,9 @@ import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
 import org.jitsi.nlj.util.`in`
 import org.jitsi.nlj.util.atRate
-import org.jitsi.nlj.util.div
 import org.jitsi.nlj.util.howMuchCanISendAtRate
 import org.jitsi.rtp.rtp.RtpPacket
+import org.jitsi.utils.div
 import java.time.Duration
 
 class RtpPacketGenerator internal constructor(

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteArray.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteArray.kt
@@ -16,8 +16,8 @@
 
 package org.jitsi.nlj.test_utils.matchers
 
-import io.kotlintest.Matcher
-import io.kotlintest.MatcherResult
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
 import org.jitsi.rtp.extensions.bytearray.toHex
 
 fun haveSameContentAs(expected: ByteArray) = object : Matcher<ByteArray> {

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteArrayBuffer/ByteArrayBuffer.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteArrayBuffer/ByteArrayBuffer.kt
@@ -16,8 +16,8 @@
 
 package org.jitsi.nlj.test_utils.matchers.ByteArrayBuffer
 
-import io.kotlintest.Matcher
-import io.kotlintest.MatcherResult
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
 import org.jitsi.rtp.extensions.toHex
 import org.jitsi.utils.ByteArrayBuffer
 

--- a/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteBuffer.kt
+++ b/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteBuffer.kt
@@ -16,8 +16,8 @@
 
 package org.jitsi.nlj.test_utils.matchers
 
-import io.kotlintest.Matcher
-import io.kotlintest.MatcherResult
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
 import java.nio.ByteBuffer
 import org.jitsi.rtp.extensions.compareToFromBeginning
 import org.jitsi.rtp.extensions.toHex

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeTeardownVisitorTest.kt
@@ -16,8 +16,8 @@
 
 package org.jitsi.nlj.transform
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.ConsumerNode
 import org.jitsi.nlj.util.PacketPredicate
@@ -70,10 +70,10 @@ internal class NodeTeardownVisitorTest : ShouldSpec() {
     }
 
     init {
-        "tearing down an 'incoming-style' pipeline" {
+        context("tearing down an 'incoming-style' pipeline") {
             NodeTeardownVisitor().visit(testIncomingPipeline)
         }
-        "tearing down an 'outgoing-style' pipeline" {
+        context("tearing down an 'outgoing-style' pipeline") {
             NodeTeardownVisitor().reverseVisit(testOutgoingPipelineTermination)
         }
     }

--- a/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/NodeVisitorTest.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.nlj.transform
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.ConsumerNode
 import org.jitsi.nlj.transform.node.Node
@@ -80,7 +80,7 @@ internal class NodeVisitorTest : ShouldSpec() {
     }
 
     init {
-        "visiting an 'incoming-style' pipeline" {
+        context("visiting an 'incoming-style' pipeline") {
             val testVisitor = TestVisitor()
             testVisitor.visit(testIncomingPipeline)
             should("visit every node") {
@@ -95,7 +95,7 @@ internal class NodeVisitorTest : ShouldSpec() {
                 testVisitor.nodeNames[5] shouldBe "Node 2 path 2 Node 2"
             }
         }
-        "visiting an 'outgoing-style' pipeline" {
+        context("visiting an 'outgoing-style' pipeline") {
             val testVisitor = TestVisitor()
             testVisitor.reverseVisit(testOutgoingPipelineTermination)
             should("visit every node") {

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/ExclusivePathDemuxerTest.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.nlj.transform.node
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.Spec
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.util.PacketPredicate
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -66,14 +66,14 @@ internal class ExclusivePathDemuxerTest : ShouldSpec() {
     }
 
     init {
-        "a packet which matches only one predicate" {
+        context("a packet which matches only one predicate") {
             demuxer.processPacket(rtcpPacket)
             should("only be demuxed to one path") {
                 rtpHandler.numReceived shouldBe 0
                 rtcpHandler.numReceived shouldBe 1
             }
         }
-        "a packet which matches more than one predicate" {
+        context("a packet which matches more than one predicate") {
             val rtpPath2 = ConditionalPacketPath()
             val handler = DummyHandler("RTP 2")
             rtpPath2.name = "RTP 2"

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingSsrcStatsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingSsrcStatsTest.kt
@@ -16,9 +16,9 @@
 
 package org.jitsi.nlj.transform.node.incoming
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.rtp.rtp.RtpPacket
 
@@ -71,7 +71,7 @@ internal class IncomingSsrcStatsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     init {
-        "Expected packet count" {
+        context("Expected packet count") {
             should("Handle cases with no rollover") {
                 IncomingSsrcStats.calculateExpectedPacketCount(
                     0,
@@ -98,7 +98,7 @@ internal class IncomingSsrcStatsTest : ShouldSpec() {
                 ) shouldBe 17 + 65536
             }
         }
-        "When receiving a series of packets with loss" {
+        context("When receiving a series of packets with loss") {
             // 17 packets between base and max sequence number, 6 packets lost
             val packetSequence = listOf(
                 createStatPacketInfo(0, 0, 0),
@@ -125,12 +125,12 @@ internal class IncomingSsrcStatsTest : ShouldSpec() {
                 )
             }
             val statSnapshot = streamStatistics.getSnapshot()
-            "expected packets" {
+            context("expected packets") {
                 should("be calculated correctly") {
                     statSnapshot.numExpectedPackets shouldBe 17
                 }
             }
-            "cumulative lost" {
+            context("cumulative lost") {
                 should("be calculated correctly") {
                     statSnapshot.cumulativePacketsLost shouldBe 6
                 }

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
@@ -19,10 +19,10 @@ package org.jitsi.nlj.transform.node.incoming
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.resources.node.onOutput
@@ -68,7 +68,7 @@ class RtcpTerminationTest : ShouldSpec() {
             (it.getArgument(0) as? RtcpSrPacket)?.reportBlocks
         }
 
-        "Receiving an SR packet" {
+        context("Receiving an SR packet") {
             val senderInfo = SenderInfoBuilder(
                 ntpTimestampMsw = 0xDEADBEEF,
                 ntpTimestampLsw = 0xBEEFDEAD,
@@ -76,7 +76,7 @@ class RtcpTerminationTest : ShouldSpec() {
                 sendersPacketCount = 42,
                 sendersOctetCount = 4242
             )
-            "without any receiver report blocks" {
+            context("without any receiver report blocks") {
                 val srPacket = RtcpSrPacketBuilder(
                     RtcpHeaderBuilder(
                         senderSsrc = 12345L
@@ -97,7 +97,7 @@ class RtcpTerminationTest : ShouldSpec() {
                     }
                 }
             }
-            "with a receiver report block" {
+            context("with a receiver report block") {
                 val reportBlock = RtcpReportBlock(
                     ssrc = 12345,
                     fractionLost = 42,

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/SrtpDecryptTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/SrtpDecryptTest.kt
@@ -16,11 +16,11 @@
 
 package org.jitsi.nlj.transform.node.incoming
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.should
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.resources.srtp_samples.SrtpSample
@@ -39,7 +39,7 @@ internal class SrtpDecryptTest : ShouldSpec() {
             StdoutLogger()
         )
 
-        "decrypting an RTCP packet" {
+        context("decrypting an RTCP packet") {
             val packetInfo = PacketInfo(SrtpSample.incomingEncryptedRtcpPacket.clone())
             srtpTransformers.srtcpDecryptTransformer.transform(packetInfo) shouldBe SrtpErrorStatus.OK
             val decryptedPacket = packetInfo.packet
@@ -50,7 +50,7 @@ internal class SrtpDecryptTest : ShouldSpec() {
             }
         }
 
-        "decrypting an RTP packet" {
+        context("decrypting an RTP packet") {
             val packetInfo = PacketInfo(SrtpSample.incomingEncryptedRtpPacket.clone())
             srtpTransformers.srtpDecryptTransformer.transform(packetInfo) shouldBe SrtpErrorStatus.OK
 

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
@@ -15,13 +15,13 @@ import org.jitsi.nlj.rtp.RtpExtension
 import org.jitsi.nlj.rtp.RtpExtensionType
 import org.jitsi.nlj.test_utils.FakeClock
 import org.jitsi.nlj.util.StreamInformationStoreImpl
-import org.jitsi.nlj.util.ms
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.ReceivedPacketReport
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.UnreceivedPacketReport
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.TccHeaderExtension
+import org.jitsi.utils.ms
 import java.util.Random
 
 class TccGeneratorNodeTest : ShouldSpec() {
@@ -54,7 +54,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
                         receivedTime = clock.millis()
                     })
-                    elapse(10.ms())
+                    elapse(10.ms)
                 }
             }
             "no TCC packets should be sent" {
@@ -67,7 +67,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
                         receivedTime = clock.millis()
                     })
-                    elapse(10.ms())
+                    elapse(10.ms)
                 }
             }
             "one TCC packet" {
@@ -87,17 +87,17 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 tccGenerator.processPacket(PacketInfo(createPacket(1)).apply {
                     receivedTime = clock.millis()
                 })
-                elapse(10.ms())
+                elapse(10.ms)
                 tccGenerator.processPacket(PacketInfo(createPacket(2)).apply {
                     receivedTime = clock.millis()
                 })
-                elapse(10.ms())
+                elapse(10.ms)
                 tccGenerator.processPacket(PacketInfo(createPacket(3).apply {
                     isMarked = true
                 }).apply {
                     receivedTime = clock.millis()
                 })
-                elapse(100.ms())
+                elapse(100.ms)
                 tccGenerator.processPacket(PacketInfo(createPacket(4)).apply {
                     receivedTime = clock.millis()
                 })
@@ -114,7 +114,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 tccGenerator.processPacket(PacketInfo(createPacket(random.nextInt(0xffff))).apply {
                     receivedTime = clock.millis()
                 })
-                clock.elapse(10.ms())
+                clock.elapse(10.ms)
 
                 tccPackets.lastOrNull()?.let {
                     it.length shouldBeLessThan 1500
@@ -131,7 +131,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 tccGenerator.processPacket(PacketInfo(createPacket(i % 0xffff)).apply {
                     receivedTime = clock.millis()
                 })
-                clock.elapse(10.ms())
+                clock.elapse(10.ms)
 
                 tccPackets.lastOrNull()?.let {
                     it.length shouldBeLessThan 1500
@@ -148,7 +148,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     receivedTime = clock.millis()
                 }
                 tccGenerator.processPacket(pi)
-                clock.elapse(10.ms())
+                clock.elapse(10.ms)
 
                 tccPackets.size shouldBeLessThanOrEqual prevSize + 1
                 prevSize = tccPackets.size
@@ -166,7 +166,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     receivedTime = clock.millis()
                 }
                 tccGenerator.processPacket(pi)
-                clock.elapse(20.ms())
+                clock.elapse(20.ms)
 
                 tccPackets.size shouldBeLessThanOrEqual prevSize + 1
                 prevSize = tccPackets.size
@@ -183,9 +183,9 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
                         receivedTime = clock.millis()
                     })
-                    elapse(10.ms())
+                    elapse(10.ms)
                 }
-                elapse(100.ms())
+                elapse(100.ms)
                 tccGenerator.processPacket(PacketInfo(createPacket(20)).apply {
                     receivedTime = clock.millis()
                 })
@@ -210,9 +210,9 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
                         receivedTime = clock.millis()
                     })
-                    elapse(10.ms())
+                    elapse(10.ms)
                 }
-                elapse(10.ms())
+                elapse(10.ms)
                 tccGenerator.processPacket(PacketInfo(createPacket(10)).apply {
                     receivedTime = clock.millis()
                 })
@@ -221,7 +221,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     receivedTime = clock.millis() - 10
                 })
 
-                elapse(100.ms())
+                elapse(100.ms)
                 tccGenerator.processPacket(PacketInfo(createPacket(20)).apply {
                     receivedTime = clock.millis()
                 })

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNodeTest.kt
@@ -1,13 +1,13 @@
 package org.jitsi.nlj.transform.node.incoming
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.Spec
-import io.kotlintest.matchers.beInstanceOf
-import io.kotlintest.matchers.numerics.shouldBeLessThan
-import io.kotlintest.matchers.numerics.shouldBeLessThanOrEqual
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.beInstanceOf
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.Vp8PayloadType
 import org.jitsi.nlj.resources.logging.StdoutLogger
@@ -47,7 +47,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
     }
 
     init {
-        "when TCC is not signaled" {
+        context("when TCC is not signaled") {
             streamInformationStore.clearRtpPayloadTypes()
             with(clock) {
                 repeat(100) { tccSeqNum ->
@@ -57,11 +57,11 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     elapse(10.ms)
                 }
             }
-            "no TCC packets should be sent" {
+            context("no TCC packets should be sent") {
                 tccPackets.size shouldBe 0
             }
         }
-        "when a series of packets (without marking) is received" {
+        context("when a series of packets (without marking) is received") {
             with(clock) {
                 repeat(11) { tccSeqNum ->
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
@@ -70,7 +70,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     elapse(10.ms)
                 }
             }
-            "one TCC packet" {
+            context("one TCC packet") {
                 should("be sent after 100ms") {
                     tccPackets.size shouldBe 1
                 }
@@ -82,7 +82,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 }
             }
         }
-        "when a series of packets (where one is marked) is received" {
+        context("when a series of packets (where one is marked) is received") {
             with(clock) {
                 tccGenerator.processPacket(PacketInfo(createPacket(1)).apply {
                     receivedTime = clock.millis()
@@ -102,13 +102,13 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     receivedTime = clock.millis()
                 })
             }
-            "two TCC packets" {
+            context("two TCC packets") {
                 should("be sent") {
                     tccPackets.size shouldBe 2
                 }
             }
         }
-        "when random packets are added" {
+        context("when random packets are added") {
             val random = Random(1234)
             for (i in 1..10000) {
                 tccGenerator.processPacket(PacketInfo(createPacket(random.nextInt(0xffff))).apply {
@@ -121,7 +121,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 }
             }
         }
-        "when a few packets covering the seq num space are added" {
+        context("when a few packets covering the seq num space are added") {
             for (i in listOf(0, 10000, 20000, 30000, 40000, 50000, 60000)) {
                 tccGenerator.processPacket(PacketInfo(createPacket(i % 0xffff)).apply {
                     receivedTime = clock.millis()
@@ -138,7 +138,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 }
             }
         }
-        "when sequence numbers cycle" {
+        context("when sequence numbers cycle") {
             var prevSize = tccPackets.size
             repeat(100000) { tccSeqNum ->
                 if (tccSeqNum > 0xffff) {
@@ -153,13 +153,13 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 tccPackets.size shouldBeLessThanOrEqual prevSize + 1
                 prevSize = tccPackets.size
             }
-            "an appropriate number of TCC packets" {
+            context("an appropriate number of TCC packets") {
                 should("be sent") {
                     tccPackets.size shouldBe 9999
                 }
             }
         }
-        "when sequence numbers cycle with losses" {
+        context("when sequence numbers cycle with losses") {
             var prevSize = tccPackets.size
             repeat(50000) { tccSeqNum ->
                 val pi = PacketInfo(createPacket((tccSeqNum * 2) % 0xffff)).apply {
@@ -171,13 +171,13 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 tccPackets.size shouldBeLessThanOrEqual prevSize + 1
                 prevSize = tccPackets.size
             }
-            "an appropriate number of TCC packets" {
+            context("an appropriate number of TCC packets") {
                 should("be sent") {
                     tccPackets.size shouldBe 9999
                 }
             }
         }
-        "when there is a loss after a TCC packet is sent" {
+        context("when there is a loss after a TCC packet is sent") {
             with(clock) {
                 repeat(11) { tccSeqNum ->
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
@@ -190,12 +190,12 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     receivedTime = clock.millis()
                 })
             }
-            "two TCC packets" {
+            context("two TCC packets") {
                 should("be sent") {
                     tccPackets.size shouldBe 2
                 }
             }
-            "last TCC packet" {
+            context("last TCC packet") {
                 should("have a base of the lost packet") {
                     val lastTcc = tccPackets[1] as RtcpFbTccPacket
                     val firstReport = lastTcc.iterator().next()
@@ -204,7 +204,7 @@ class TccGeneratorNodeTest : ShouldSpec() {
                 }
             }
         }
-        "when there is a packet reordering after a TCC packet is sent" {
+        context("when there is a packet reordering after a TCC packet is sent") {
             with(clock) {
                 repeat(9) { tccSeqNum ->
                     tccGenerator.processPacket(PacketInfo(createPacket(tccSeqNum)).apply {
@@ -226,12 +226,12 @@ class TccGeneratorNodeTest : ShouldSpec() {
                     receivedTime = clock.millis()
                 })
             }
-            "two TCC packets" {
+            context("two TCC packets") {
                 should("be sent") {
                     tccPackets.size shouldBe 2
                 }
             }
-            "last TCC packet" {
+            context("last TCC packet") {
                 should("have a base of the reordered packet") {
                     val lastTcc = tccPackets[1] as RtcpFbTccPacket
                     val firstReport = lastTcc.iterator().next()

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParserTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParserTest.kt
@@ -18,9 +18,9 @@ package org.jitsi.nlj.transform.node.incoming
 
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import io.kotlintest.IsolationMode
-import io.kotlintest.fail
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.assertions.fail
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.format.Vp8PayloadType
@@ -93,8 +93,8 @@ class VideoParserTest : ShouldSpec() {
     }
 
     init {
-        "When parsing a VP8 packet" {
-            "with no encoding signaled" {
+        context("When parsing a VP8 packet") {
+            context("with no encoding signaled") {
                 parser.onOutput { pi ->
                     fail("Should not forward the packet")
                 }

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSenderTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSenderTest.kt
@@ -16,11 +16,11 @@
 
 package org.jitsi.nlj.transform.node.outgoing
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.TestCase
-import io.kotlintest.matchers.instanceOf
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.instanceOf
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.RtxPayloadType
 import org.jitsi.nlj.resources.logging.StdoutLogger
@@ -67,8 +67,8 @@ class RetransmissionSenderTest : ShouldSpec() {
     }
 
     init {
-        "retransmitting a packet" {
-            "which has an associated rtx stream" {
+        context("retransmitting a packet") {
+            context("which has an associated rtx stream") {
                 should("rewrite the payload type and ssrc correctly") {
                     retransmissionSender.onOutput {
                         it.packet shouldBe instanceOf(RtpPacket::class)
@@ -80,7 +80,7 @@ class RetransmissionSenderTest : ShouldSpec() {
                     retransmissionSender.processPacket(dummyPacketInfo)
                 }
             }
-            "which does not have an associated rtx stream" {
+            context("which does not have an associated rtx stream") {
                 val noRtxPacket = dummyPacket.clone().apply {
                     payloadType = 99
                     ssrc = 9876L

--- a/src/test/kotlin/org/jitsi/nlj/transform/node/outgoing/SrtpEncryptTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/transform/node/outgoing/SrtpEncryptTest.kt
@@ -16,11 +16,11 @@
 
 package org.jitsi.nlj.transform.node.outgoing
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.should
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.resources.srtp_samples.SrtpSample
@@ -44,8 +44,8 @@ internal class SrtpEncryptTest : ShouldSpec() {
             StdoutLogger()
         )
 
-        "encrypting an RTCP packet" {
-            "created from a buffer" {
+        context("encrypting an RTCP packet") {
+            context("created from a buffer") {
                 val packetInfo = PacketInfo(SrtpSample.outgoingUnencryptedRtcpPacket.clone())
                 srtpTransformers.srtcpEncryptTransformer.transform(packetInfo) shouldBe SrtpErrorStatus.OK
 
@@ -55,7 +55,7 @@ internal class SrtpEncryptTest : ShouldSpec() {
                     encryptedPacket should haveSameContentAs(SrtpSample.expectedEncryptedRtcpPacket)
                 }
             }
-            "created from values" {
+            context("created from values") {
                 val originalPacket = RtcpFbNackPacketBuilder(
                     mediaSourceSsrc = 123,
                     missingSeqNums = (10..20 step 2).toSortedSet()
@@ -74,7 +74,7 @@ internal class SrtpEncryptTest : ShouldSpec() {
             }
         }
 
-        "encrypting an RTP packet" {
+        context("encrypting an RTP packet") {
             val packetInfo = PacketInfo(SrtpSample.outgoingUnencryptedRtpPacket.clone())
             srtpTransformers.srtpEncryptTransformer.transform(packetInfo) shouldBe SrtpErrorStatus.OK
 

--- a/src/test/kotlin/org/jitsi/nlj/util/ArrayCacheTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/ArrayCacheTest.kt
@@ -16,9 +16,9 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.matchers.numerics.shouldBeGreaterThanOrEqual
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 
 internal class ArrayCacheTest : ShouldSpec() {
 
@@ -42,21 +42,21 @@ internal class ArrayCacheTest : ShouldSpec() {
         var numInserts = 0
         var numOldInserts = 0
 
-        "adding and retrieving items " {
+        context("adding and retrieving items ") {
             arrayCache.insertItem(data1, data1.index) shouldBe true
             arrayCache.getContainer(data1.index)!!.item shouldBe data1
             numInserts++
             numHits++
         }
 
-        "adding and retrieving older items " {
+        context("adding and retrieving older items ") {
             arrayCache.insertItem(dataOlder, dataOlder.index) shouldBe true
             arrayCache.getContainer(dataOlder.index)!!.item shouldBe dataOlder
             numInserts++
             numHits++
         }
 
-        "adding an item with an index which is too old, and retrieving existing data " {
+        context("adding an item with an index which is too old, and retrieving existing data ") {
             arrayCache.insertItem(dataTooOld, dataTooOld.index) shouldBe false
             arrayCache.getContainer(data1.index)!!.item shouldBe data1
             arrayCache.getContainer(dataOlder.index)!!.item shouldBe dataOlder
@@ -64,7 +64,7 @@ internal class ArrayCacheTest : ShouldSpec() {
             numHits += 2
         }
 
-        "replacing the data at the latest index" {
+        context("replacing the data at the latest index") {
             val otherData = Dummy(11111)
             arrayCache.insertItem(otherData, 100) shouldBe true
             arrayCache.getContainer(100)!!.item shouldBe otherData
@@ -72,7 +72,7 @@ internal class ArrayCacheTest : ShouldSpec() {
             numHits++
         }
 
-        "replacing the data at an older index" {
+        context("replacing the data at an older index") {
             val otherData = Dummy(22222)
             arrayCache.insertItem(otherData, 98) shouldBe true
             arrayCache.getContainer(98)!!.item shouldBe otherData
@@ -80,7 +80,7 @@ internal class ArrayCacheTest : ShouldSpec() {
             numHits++
         }
 
-        "adding and retrieving more data" {
+        context("adding and retrieving more data") {
             arrayCache.insertItem(dataNewer, dataNewer.index) shouldBe true
             arrayCache.getContainer(dataNewer.index)!!.item shouldBe dataNewer
             numInserts++
@@ -94,7 +94,7 @@ internal class ArrayCacheTest : ShouldSpec() {
             numHits++
         }
 
-        "iterate forEachDescending" {
+        context("iterate forEachDescending") {
             // This should iterate for 200..195. It should not touch the miss/hit count or
             var nextExpected = 200
             val lastExpected = 195
@@ -105,21 +105,21 @@ internal class ArrayCacheTest : ShouldSpec() {
                 nextExpected >= lastExpected
             }
         }
-        "retrieving rewritten data" {
+        context("retrieving rewritten data") {
             arrayCache.getContainer(data1.index) shouldBe null
             numMisses++
         }
-        "retrieving data with a newer index" {
+        context("retrieving data with a newer index") {
             arrayCache.getContainer(1000) shouldBe null
             numMisses++
         }
-        "keeping track of statistics " {
+        context("keeping track of statistics ") {
             arrayCache.numInserts shouldBe numInserts
             arrayCache.numOldInserts shouldBe numOldInserts
             arrayCache.numHits shouldBe numHits
             arrayCache.numMisses shouldBe numMisses
         }
-        "flush should discard all items" {
+        context("flush should discard all items") {
             arrayCache.discarded = 0
             arrayCache.flush()
             arrayCache.discarded shouldBe arrayCache.size

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -16,24 +16,23 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.matchers.beGreaterThan
-import io.kotlintest.seconds
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.jitsi.utils.secs
 
 class BandwidthTest : ShouldSpec() {
 
     init {
-        "equivalent bandwidths" {
+        context("equivalent bandwidths") {
             should("match even if created differently") {
                 2.5.mbps shouldBe 2_500_000.bps
                 2500.kbps shouldBe 2.5.mbps
             }
         }
-        "arithmetic operations on bandwidths" {
+        context("arithmetic operations on bandwidths") {
             should("work correctly") {
                 1.kbps * 10 shouldBe 10.kbps
                 1.mbps + 500.kbps shouldBe 1.5.mbps
@@ -42,7 +41,7 @@ class BandwidthTest : ShouldSpec() {
                 1.mbps / 4.mbps shouldBe 0.25
             }
         }
-        "operation-assign operations on bandwidths" {
+        context("operation-assign operations on bandwidths") {
             should("work correctly") {
                 var b = 1.mbps
                 b += 0.5.mbps
@@ -69,34 +68,34 @@ class BandwidthTest : ShouldSpec() {
                 b.bps shouldBe 500_000.0
             }
         }
-        "printing bandwidths" {
+        context("printing bandwidths") {
             should("print as the most appropriate unit") {
                 2_500_000.bps.toString() shouldBe "2.5 mbps"
                 500_000.bps.toString() shouldBe "500 kbps"
                 .001.mbps.toString() shouldBe "1 kbps"
             }
         }
-        "comparing bandwidths" {
-            "with integral bps" {
+        context("comparing bandwidths") {
+            context("with integral bps") {
                 should("work correctly") {
-                    2.mbps should beGreaterThan(1.mbps)
-                    1000.bps should beGreaterThan(999.bps)
+                    2.mbps shouldBeGreaterThan 1.mbps
+                    1000.bps shouldBeGreaterThan 999.bps
                 }
             }
-            "with fractional bps" {
+            context("with fractional bps") {
                 should("work correctly") {
                     0.2.bps shouldNotBe 0.bps
-                    0.2.bps should beGreaterThan(0.1.bps)
+                    0.2.bps shouldBeGreaterThan 0.1.bps
                 }
             }
         }
-        "creation from 'per'" {
+        context("creation from 'per'") {
             should("work correctly") {
-                1.megabytes.per(1.seconds) shouldBe 8.mbps
-                2.bits.per(5.seconds) shouldBe 0.4.bps
+                1.megabytes.per(1.secs) shouldBe 8.mbps
+                2.bits.per(5.secs) shouldBe 0.4.bps
             }
         }
-        "creation from a string" {
+        context("creation from a string") {
             should("work correctly") {
                 Bandwidth.fromString("10mbps") shouldBe 10.mbps
                 Bandwidth.fromString("10bps") shouldBe 10.bps

--- a/src/test/kotlin/org/jitsi/nlj/util/DataSizeTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/DataSizeTest.kt
@@ -16,28 +16,27 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.matchers.beGreaterThan
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
 
 class DataSizeTest : ShouldSpec() {
 
     init {
-        "equivalent data sizes" {
+        context("equivalent data sizes") {
             should("match even if created differently") {
                 1000.bytes shouldBe 1.kilobytes
                 1.megabytes shouldBe 8_000_000.bits
             }
         }
-        "arithmetic operations" {
+        context("arithmetic operations") {
             should("work correctly") {
                 1.kilobytes + 1.kilobytes shouldBe 2.kilobytes
                 1.megabytes - 500.kilobytes shouldBe 500.kilobytes
                 1.bytes * 10 shouldBe 10.bytes
             }
         }
-        "printing data sizes" {
+        context("printing data sizes") {
             should("print as the most appropriate unit") {
                 8_000_000.bits.toString() shouldBe "1 MB"
                 1000.bytes.toString() shouldBe "1 KB"
@@ -45,10 +44,10 @@ class DataSizeTest : ShouldSpec() {
                 4.bits.toString() shouldBe "4 bits"
             }
         }
-        "comparing data sizes" {
+        context("comparing data sizes") {
             should("work correctly") {
-                2.megabytes should beGreaterThan(1.megabytes)
-                1000.bits should beGreaterThan(999.bits)
+                2.megabytes shouldBeGreaterThan 1.megabytes
+                1000.bits shouldBeGreaterThan 999.bits
             }
         }
     }

--- a/src/test/kotlin/org/jitsi/nlj/util/ExecutorUtilsKtTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/ExecutorUtilsKtTest.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.ShouldSpec
-import java.time.Duration
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import org.jitsi.utils.secs
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 
@@ -29,8 +29,8 @@ internal class ExecutorUtilsKtTest : ShouldSpec() {
     private val executor = Executors.newSingleThreadExecutor()
 
     init {
-        "shutting down an executor" {
-            "with a blocked task which can be interrupted" {
+        context("shutting down an executor") {
+            context("with a blocked task which can be interrupted") {
                 val queue = LinkedBlockingQueue<Int>()
                 executor.submit {
                     queue.take()
@@ -40,9 +40,9 @@ internal class ExecutorUtilsKtTest : ShouldSpec() {
                 Thread.sleep(1000)
 
                 // This should not throw
-                executor.safeShutdown(Duration.ofSeconds(1))
+                executor.safeShutdown(1.secs)
             }
-            "with an uninterruptable task" {
+            context("with an uninterruptable task") {
                 val queue = LinkedBlockingQueue<Int>()
                 executor.submit {
                     while (true) {
@@ -56,7 +56,7 @@ internal class ExecutorUtilsKtTest : ShouldSpec() {
                 Thread.sleep(1000)
 
                 shouldThrow<ExecutorShutdownTimeoutException> {
-                    executor.safeShutdown(Duration.ofSeconds(1))
+                    executor.safeShutdown(1.secs)
                 }
             }
         }

--- a/src/test/kotlin/org/jitsi/nlj/util/OrderedJsonObjectTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/OrderedJsonObjectTest.kt
@@ -16,14 +16,14 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.matchers.collections.shouldContainExactly
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
 
 class OrderedJsonObjectTest : ShouldSpec() {
 
     init {
-        "an ordered json object" {
+        context("an ordered json object") {
             val ojo = OrderedJsonObject()
             ojo["one"] = 1
             ojo["two"] = 2

--- a/src/test/kotlin/org/jitsi/nlj/util/RateUtilsKtTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/RateUtilsKtTest.kt
@@ -16,23 +16,22 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
 import org.jitsi.utils.ms
-import java.time.Duration
+import org.jitsi.utils.secs
 
 class RateUtilsKtTest : ShouldSpec() {
 
     init {
-        "atRate" {
+        context("atRate") {
             should("work correctly") {
-                1.megabytes atRate 1.mbps shouldBe Duration.ofSeconds(8)
+                1.megabytes atRate 1.mbps shouldBe 8.secs
             }
         }
-        "in" {
+        context("in") {
             should("work correctly") {
-                val size = howMuchCanISendAtRate(1.mbps).`in`(8.seconds)
+                val size = howMuchCanISendAtRate(1.mbps).`in`(8.secs)
                 size shouldBe 1.megabytes
             }
             should("work correctly for fractional durations") {

--- a/src/test/kotlin/org/jitsi/nlj/util/RateUtilsKtTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/RateUtilsKtTest.kt
@@ -19,6 +19,7 @@ package org.jitsi.nlj.util
 import io.kotlintest.seconds
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.ShouldSpec
+import org.jitsi.utils.ms
 import java.time.Duration
 
 class RateUtilsKtTest : ShouldSpec() {
@@ -35,7 +36,7 @@ class RateUtilsKtTest : ShouldSpec() {
                 size shouldBe 1.megabytes
             }
             should("work correctly for fractional durations") {
-                val size = howMuchCanISendAtRate(1.mbps).`in`(800.milliseconds())
+                val size = howMuchCanISendAtRate(1.mbps).`in`(800.ms)
                 size shouldBe 100.kilobytes
             }
         }

--- a/src/test/kotlin/org/jitsi/nlj/util/ResumableStreamRewriterTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/ResumableStreamRewriterTest.kt
@@ -16,82 +16,82 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.matchers.withClue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
 import org.jitsi.nlj.rtp.ResumableStreamRewriter
 
 internal class ResumableStreamRewriterTest : ShouldSpec() {
     init {
-        "Without history" {
+        context("Without history") {
             var ret: Int
             val snr = ResumableStreamRewriter(false)
 
-            "Initial state" {
+            context("Initial state") {
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe -1
             }
 
-            "Accept first packet." {
+            context("Accept first packet.") {
                 ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0xffff - 2
                 ret shouldBe 0xffff - 2
             }
 
-            "Retransmission." {
+            context("Retransmission.") {
                 ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0xffff - 2
                 ret shouldBe 0xffff - 2
             }
 
-            "Retransmission & accept toggle." {
+            context("Retransmission & accept toggle.") {
                 snr.rewriteSequenceNumber(false, 0xffff - 2)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0xffff - 2
             }
 
-            "Retransmission & accept toggle again." {
+            context("Retransmission & accept toggle again.") {
                 ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0xffff - 2
                 ret shouldBe 0xffff - 2
             }
 
-            "Drop ordered packet." {
+            context("Drop ordered packet.") {
                 snr.rewriteSequenceNumber(false, 0xffff - 1)
                 snr.seqnumDelta shouldBe 1
                 snr.highestSequenceNumberSent shouldBe 0xffff - 2
             }
 
-            "Drop re-ordered packet." {
+            context("Drop re-ordered packet.") {
                 snr.rewriteSequenceNumber(false, 0xffff - 3)
                 snr.seqnumDelta shouldBe 1
                 snr.highestSequenceNumberSent shouldBe 0xffff - 2
             }
 
-            "Accept after re-ordered drop." {
+            context("Accept after re-ordered drop.") {
                 ret = snr.rewriteSequenceNumber(true, 0xffff)
                 snr.seqnumDelta shouldBe 1
                 snr.highestSequenceNumberSent shouldBe 0xffff - 1
                 ret shouldBe 0xffff - 1
             }
 
-            "Drop ordered packet again." {
+            context("Drop ordered packet again.") {
                 snr.rewriteSequenceNumber(false, 0)
                 snr.seqnumDelta shouldBe 2
                 snr.highestSequenceNumberSent shouldBe 0xffff - 1
             }
 
-            "Accept ordered packet." {
+            context("Accept ordered packet.") {
                 ret = snr.rewriteSequenceNumber(true, 1)
                 snr.seqnumDelta shouldBe 2
                 snr.highestSequenceNumberSent shouldBe 0xffff
                 ret shouldBe 0xffff
             }
 
-            "Drop ordered packets." {
+            context("Drop ordered packets.") {
                 for (i in 2 until 0xffff) {
                     withClue("index = $i") {
                         snr.rewriteSequenceNumber(false, i)
@@ -101,20 +101,20 @@ internal class ResumableStreamRewriterTest : ShouldSpec() {
                 }
             }
 
-            "Drop ordered packet again(2)" {
+            context("Drop ordered packet again(2)") {
                 snr.rewriteSequenceNumber(false, 0xffff)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0xffff
             }
 
-            "Accept ordered packet again" {
+            context("Accept ordered packet again") {
                 ret = snr.rewriteSequenceNumber(true, 0)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0
                 ret shouldBe 0
             }
 
-            "Retransmission + accept toggle" {
+            context("Retransmission + accept toggle") {
                 ret = snr.rewriteSequenceNumber(true, 0xffff)
                 snr.seqnumDelta shouldBe 0
                 snr.highestSequenceNumberSent shouldBe 0
@@ -122,54 +122,54 @@ internal class ResumableStreamRewriterTest : ShouldSpec() {
             }
         }
 
-        "With history" {
+        context("With history") {
             /* The same as the trace above, other than checking internal state. */
-            "In-order trace" {
+            context("In-order trace") {
                 var ret: Int
                 val snr = ResumableStreamRewriter(true)
 
-                "Accept first packet." {
+                context("Accept first packet.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                     ret shouldBe 0xffff - 2
                 }
 
-                "Retransmission." {
+                context("Retransmission.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                     ret shouldBe 0xffff - 2
                 }
 
-                "Retransmission & accept toggle." {
+                context("Retransmission & accept toggle.") {
                     snr.rewriteSequenceNumber(false, 0xffff - 2)
                 }
 
-                "Retransmission & accept toggle again." {
+                context("Retransmission & accept toggle again.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                     ret shouldBe 0xffff - 2
                 }
 
-                "Drop ordered packet." {
+                context("Drop ordered packet.") {
                     snr.rewriteSequenceNumber(false, 0xffff - 1)
                 }
 
-                "Drop re-ordered packet." {
+                context("Drop re-ordered packet.") {
                     snr.rewriteSequenceNumber(false, 0xffff - 3)
                 }
 
-                "Accept after re-ordered drop." {
+                context("Accept after re-ordered drop.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff)
                     ret shouldBe 0xffff - 1
                 }
 
-                "Drop ordered packet again." {
+                context("Drop ordered packet again.") {
                     snr.rewriteSequenceNumber(false, 0)
                 }
 
-                "Accept ordered packet." {
+                context("Accept ordered packet.") {
                     ret = snr.rewriteSequenceNumber(true, 1)
                     ret shouldBe 0xffff
                 }
 
-                "Drop ordered packets." {
+                context("Drop ordered packets.") {
                     for (i in 2 until 0xffff) {
                         withClue("index = $i") {
                             snr.rewriteSequenceNumber(false, i)
@@ -177,85 +177,85 @@ internal class ResumableStreamRewriterTest : ShouldSpec() {
                     }
                 }
 
-                "Drop ordered packet again(2)" {
+                context("Drop ordered packet again(2)") {
                     snr.rewriteSequenceNumber(false, 0xffff)
                 }
 
-                "Accept ordered packet again" {
+                context("Accept ordered packet again") {
                     ret = snr.rewriteSequenceNumber(true, 0)
                     ret shouldBe 0
                 }
 
-                "Retransmission + accept toggle" {
+                context("Retransmission + accept toggle") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff)
                     ret shouldBe 0xffff
                 }
             }
 
-            "Reordering trace" {
+            context("Reordering trace") {
                 var ret: Int
                 val snr = ResumableStreamRewriter(true)
 
-                "Accept first packet." {
+                context("Accept first packet.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff - 2)
                     ret shouldBe 0xffff - 2
                 }
 
-                "Drop packet one after." {
+                context("Drop packet one after.") {
                     snr.rewriteSequenceNumber(false, 0xffff - 1)
                 }
 
-                "Accept next packet." {
+                context("Accept next packet.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff)
                     ret shouldBe 0xffff - 1
                 }
 
-                "Drop packet before first." {
+                context("Drop packet before first.") {
                     snr.rewriteSequenceNumber(false, 0xffff - 3)
                 }
 
-                "Accept packet before that." {
+                context("Accept packet before that.") {
                     ret = snr.rewriteSequenceNumber(true, 0xffff - 4)
                     ret shouldBe 0xffff - 3
                 }
 
-                "Drop packet after a gap" {
+                context("Drop packet after a gap") {
                     snr.rewriteSequenceNumber(false, 1)
                 }
 
-                "And another" {
+                context("And another") {
                     snr.rewriteSequenceNumber(false, 2)
                 }
 
-                "Accept packet after gap" {
+                context("Accept packet after gap") {
                     ret = snr.rewriteSequenceNumber(true, 3)
                     ret shouldBe 0
                 }
 
-                "Accept packet filling gap" {
+                context("Accept packet filling gap") {
                     ret = snr.rewriteSequenceNumber(true, 0)
                     ret shouldBe 0xffff
                 }
 
-                "Accept packet after another gap" {
+                context("Accept packet after another gap") {
                     ret = snr.rewriteSequenceNumber(true, 6)
                     ret shouldBe 3
                 }
 
-                "Check Gaps Left statistics" {
+                context("Check Gaps Left statistics") {
                     snr.gapsLeft shouldBe 0
                     snr.rewriteSequenceNumber(false, 4)
 
                     snr.gapsLeft shouldBe 1
                 }
 
-                "Check Gaps Left statistics on replay of drop" {
+                context("Check Gaps Left statistics on replay of drop") {
                     snr.rewriteSequenceNumber(false, 4)
 
                     snr.gapsLeft shouldBe 1
                 }
 
-                "Verify that replay of accept works" {
+                context("Verify that replay of accept works") {
                     ret = snr.rewriteSequenceNumber(true, 0)
                     ret shouldBe 0xffff
                 }

--- a/src/test/kotlin/org/jitsi/nlj/util/Rfc3711IndexTrackerTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/Rfc3711IndexTrackerTest.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.numerics.shouldBeGreaterThan
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
 
 internal class Rfc3711IndexTrackerTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
@@ -27,29 +27,29 @@ internal class Rfc3711IndexTrackerTest : ShouldSpec() {
     private val indexTracker = Rfc3711IndexTracker()
 
     init {
-        "feeding in the first sequence number" {
+        context("feeding in the first sequence number") {
             val firstIndex = indexTracker.update(65000)
             should("return itself as the index") {
                 firstIndex shouldBe 65000
             }
-            "and then another without rolling over" {
+            context("and then another without rolling over") {
                 val secondIndex = indexTracker.update(65001)
                 should("return itself as the index") {
                     secondIndex shouldBe 65001
                 }
-                "and then another which does roll over" {
+                context("and then another which does roll over") {
                     val rollOverIndex = indexTracker.update(2)
                     should("return the proper index") {
                         rollOverIndex shouldBe 1 /* roc */ * 0x1_0000 + 2
                     }
-                    "and then a sequence number from the previous rollover" {
+                    context("and then a sequence number from the previous rollover") {
                         val prevRollOverIndex = indexTracker.update(65002)
                         should("return the proper index") {
                             prevRollOverIndex shouldBe 65002
                         }
                     }
                 }
-                "and then an older sequence number" {
+                context("and then an older sequence number") {
                     val oldIndex = indexTracker.update(64000)
                     should("return the proper index") {
                         oldIndex shouldBe oldIndex
@@ -57,7 +57,7 @@ internal class Rfc3711IndexTrackerTest : ShouldSpec() {
                 }
             }
         }
-        "a series of sequence numbers" {
+        context("a series of sequence numbers") {
             should("never return a negative index") {
                 var seqNum = 22134
                 repeat(35537) {

--- a/src/test/kotlin/org/jitsi/nlj/util/RtpPacketExtensionsKtTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/RtpPacketExtensionsKtTest.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.should
 import java.nio.ByteBuffer
 import org.jitsi.nlj.test_utils.matchers.haveSameContentAs
 import org.jitsi.rtp.extensions.plus
@@ -47,8 +47,8 @@ class RtpPacketExtensionsKtTest : ShouldSpec() {
     val rtpPacket = RtpPacket(buf)
 
     init {
-        "shiftPayloadRight" {
-            "when the buffer doesn't have any room" {
+        context("shiftPayloadRight") {
+            context("when the buffer doesn't have any room") {
                 rtpPacket.shiftPayloadRight(2)
                 should("shift things correctly") {
                     // Header should be the same

--- a/src/test/kotlin/org/jitsi/nlj/util/TimeExpiringCacheTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/TimeExpiringCacheTest.kt
@@ -16,14 +16,14 @@
 
 package org.jitsi.nlj.util
 
-import io.kotlintest.IsolationMode
-import io.kotlintest.matchers.types.shouldBeSameInstanceAs
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
-import io.kotlintest.specs.ShouldSpec
-import java.time.Duration
-import java.time.Instant
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.jitsi.nlj.test_utils.FakeClock
+import org.jitsi.utils.secs
+import java.time.Instant
 
 internal class TimeExpiringCacheTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
@@ -33,24 +33,24 @@ internal class TimeExpiringCacheTest : ShouldSpec() {
     private val fakeClock = FakeClock()
 
     private val timeExpiringCache = TimeExpiringCache<Int, Dummy>(
-            Duration.ofSeconds(1),
+            1.secs,
             20,
             fakeClock
     )
 
     init {
-        "adding data" {
+        context("adding data") {
             val data1 = Dummy(1)
             timeExpiringCache.insert(data1.num, data1)
-            "and then retrieving it before the timeout has elapsed" {
+            context("and then retrieving it before the timeout has elapsed") {
                 val retrievedData1 = timeExpiringCache.get(data1.num)
                 should("return the data") {
                     retrievedData1 shouldNotBe null
                     retrievedData1 shouldBeSameInstanceAs data1
                 }
             }
-            "and then retrieving it after the timeout has elapsed" {
-                fakeClock.elapse(Duration.ofSeconds(5))
+            context("and then retrieving it after the timeout has elapsed") {
+                fakeClock.elapse(5.secs)
                 val retrievedData1 = timeExpiringCache.get(data1.num)
                 // We don't prune on 'get', only on 'insert'
                 should("return the data") {
@@ -58,11 +58,11 @@ internal class TimeExpiringCacheTest : ShouldSpec() {
                     retrievedData1 shouldBeSameInstanceAs data1
                 }
             }
-            "and then adding more data > timeout period later" {
+            context("and then adding more data > timeout period later") {
                 val data2 = Dummy(2)
-                fakeClock.elapse(Duration.ofSeconds(5))
+                fakeClock.elapse(5.secs)
                 timeExpiringCache.insert(data2.num, data2)
-                "and then trying to retrieve the old data" {
+                context("and then trying to retrieve the old data") {
                     val retrievedData1 = timeExpiringCache.get(data1.num)
                     should("return null") {
                         retrievedData1 shouldBe null
@@ -70,10 +70,10 @@ internal class TimeExpiringCacheTest : ShouldSpec() {
                 }
             }
         }
-        "adding lots of data over time" {
+        context("adding lots of data over time") {
             for (i in 1..10) {
                 timeExpiringCache.insert(i, Dummy(i))
-                fakeClock.elapse(Duration.ofSeconds(1))
+                fakeClock.elapse(1.secs)
             }
             should("expire things properly") {
                 // Only the last value should still be present
@@ -83,12 +83,12 @@ internal class TimeExpiringCacheTest : ShouldSpec() {
                 timeExpiringCache.get(10) shouldNotBe null
             }
         }
-        "adding data at the same time" {
+        context("adding data at the same time") {
             for (i in 1..10) {
                 timeExpiringCache.insert(i, Dummy(i))
             }
-            "and then another > timeout period later" {
-                fakeClock.elapse(Duration.ofSeconds(10))
+            context("and then another > timeout period later") {
+                fakeClock.elapse(10.secs)
                 timeExpiringCache.insert(11, Dummy(11))
                 should("expire all the old data") {
                     for (i in 1..10) {
@@ -97,7 +97,7 @@ internal class TimeExpiringCacheTest : ShouldSpec() {
                 }
             }
         }
-        "adding data out of order" {
+        context("adding data out of order") {
             // Here we simulate data being inserted out of order (with relation
             // to their index value)
             timeExpiringCache.insert(1, Dummy(1))
@@ -119,7 +119,7 @@ internal class TimeExpiringCacheTest : ShouldSpec() {
                 timeExpiringCache.get(4) shouldNotBe null
             }
         }
-        "adding more than the maximum amount of elements" {
+        context("adding more than the maximum amount of elements") {
             for (i in 1..20) {
                 timeExpiringCache.insert(i, Dummy(i))
             }


### PR DESCRIPTION
This started as upgrading kotlintest to kotest in JMT, but then since kotest got rid of the helpers for creating `Duration` it got into an upgrade for jitsi-utils as well, and then updating metaconfig, so that stuff is in here too.