### PR TITLE
Add kotest-runner-console-jvm for IntelliJ kotest tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.71</kotlin.version>
+        <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
         <junit.version>5.2.0</junit.version>
         <bouncycastle.version>1.65</bouncycastle.version>
@@ -114,6 +114,12 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-property-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-console-jvm</artifactId>
             <version>${kotest.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Bump kotlin to latest 1.3.