### PR TITLE
FEAT: Add a feedbackComplete interface to BandwidthEstimator.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -157,6 +157,8 @@ class TransportCcEngine(
                 }
             }
         }
+        bandwidthEstimator.feedbackComplete(now)
+
         if (missingPacketDetailSeqNums.isNotEmpty()) {
             logger.warn("TCC packet contained received sequence numbers: " +
                 "${tccPacket.iterator().asSequence()

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
@@ -73,6 +73,10 @@ abstract class BandwidthEstimator(
      * necessarily have any relationship to each other, but must be consistent
      * within themselves across all calls to functions of this [BandwidthEstimator].
      *
+     * All arrival and loss reports based on a single feedback message should have the
+     * same [now] value.  [feedbackComplete] should be called once all feedback reports
+     * based on a single feedback message have been processed.
+     *
      * @param[now] The current time, when this function is called.
      * @param[sendTime] The time the packet was sent, if known, or null.
      * @param[recvTime] The time the packet was received, if known, or null.
@@ -125,6 +129,10 @@ abstract class BandwidthEstimator(
     /**
      * Inform the bandwidth estimator that a packet was lost.
      *
+     * All arrival and loss reports based on a single feedback message should have the
+     * same [now] value.  [feedbackComplete] should be called once all feedback reports
+     * based on a single feedback message have been processed.
+     *
      * @param[now] The current time, when this function is called.
      * @param[sendTime] The time the packet was sent, if known, or null.
      * @param[seq] A 16-bit sequence number of packets processed by this
@@ -149,6 +157,28 @@ abstract class BandwidthEstimator(
      * See that function for parameter details.
      */
     protected abstract fun doProcessPacketLoss(now: Instant, sendTime: Instant?, seq: Int)
+
+    /**
+     * Inform the bandwidth estimator that a block of feedback is complete.
+     *
+     * @param[now] The current time, when this function is called.  This should match
+     *   the value passed to [processPacketArrival] and [processPacketLoss].
+     */
+    fun feedbackComplete(now: Instant) {
+        if (timeSeriesLogger.isTraceEnabled) {
+            val point = diagnosticContext.makeTimeSeriesPoint("bwe_feedback_complete", now)
+            timeSeriesLogger.trace(point)
+        }
+
+        doFeedbackComplete(now)
+    }
+
+    /**
+     * A subclass's implementation of [feedbackComplete].
+     *
+     * See that function for parameter details.
+     */
+    protected abstract fun doFeedbackComplete(now: Instant)
 
     /**
      * Inform the bandwidth estimator about a new round-trip time value

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
@@ -83,14 +83,14 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
         }
         sendSideBandwidthEstimation.updateReceiverEstimate(bitrateEstimatorAbsSendTime.latestEstimate)
         sendSideBandwidthEstimation.reportPacketArrived(now.toEpochMilli())
-
-        /* TODO: rate-limit how often we call updateEstimate? */
-        sendSideBandwidthEstimation.updateEstimate(now.toEpochMilli())
-        reportBandwidthEstimate(now, sendSideBandwidthEstimation.latestEstimate.bps)
     }
 
     override fun doProcessPacketLoss(now: Instant, sendTime: Instant?, seq: Int) {
         sendSideBandwidthEstimation.reportPacketLost(now.toEpochMilli())
+    }
+
+    override fun doFeedbackComplete(now: Instant) {
+        /* TODO: rate-limit how often we call updateEstimate? */
         sendSideBandwidthEstimation.updateEstimate(now.toEpochMilli())
         reportBandwidthEstimate(now, sendSideBandwidthEstimation.latestEstimate.bps)
     }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
@@ -98,12 +98,15 @@ class RemoteBandwidthEstimator(
         astExtId?.let {
             val rtpPacket = packetInfo.packetAs<RtpPacket>()
             rtpPacket.getHeaderExtension(it)?.let { ext ->
+                val now = clock.instant()
                 bwe.processPacketArrival(
-                    clock.instant(),
+                    now,
                     AbsSendTimeHeaderExtension.getTime(ext),
                     Instant.ofEpochMilli(packetInfo.receivedTime),
                     rtpPacket.sequenceNumber,
                     rtpPacket.length.bytes)
+                /* With receiver-side bwe we need to treat each received packet as separate feedback */
+                bwe.feedbackComplete(now)
                 ssrcs.add(rtpPacket.ssrc)
             }
         } ?: numPacketsWithoutAbsSendTime++

--- a/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
@@ -177,6 +177,7 @@ class PacketReceiver(
         /* All delay is send -> receive in this simulation, so one-way delay is rtt. */
         estimator.onRttUpdate(now, Duration.between(packet.sendTime, now))
         estimator.processPacketArrival(now, packet.sendTime, now, seq, packet.packetSize)
+        estimator.feedbackComplete(now)
         seq++
         val bw = estimator.getCurrentBw(now)
         if (timeSeriesLogger.isTraceEnabled) {


### PR DESCRIPTION
Call it when we've processed a complete tcc packet.

This lets us recalculate bwe once per feedback packet, rather than once per packet reported on.