### PR TITLE
Shorten bitrate calculation window to adapt for bandwidth changes faster

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -166,7 +166,7 @@ constructor(
          *
          * TODO maybe make this configurable.
          */
-        const val AVERAGE_BITRATE_WINDOW_MS = 5000
+        const val AVERAGE_BITRATE_WINDOW_MS = 1000
 
         /**
          * Calculate the "id" of a layer based on its encoding, spatial, and temporal ID.


### PR DESCRIPTION
This PR is related to [PR#1439](https://github.com/jitsi/jitsi-videobridge/pull/1439). It would be better to reduce bitrate calculator back window in order to speed up RateStatistics warm-up period and reach minimal bitrate threshold faster.