### PR TITLE
Set the default SRTP factory class.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -23,12 +23,23 @@ jmt {
     # This is useful to avoid unnecessary computation for audio silence.
     max-consecutive-packets-discarded-early=-1
 
-    // The DTLS-SRTP protection profiles that are supported, in preference order.
+    # The DTLS-SRTP protection profiles that are supported, in preference order.
     protection-profiles=[
         "SRTP_AEAD_AES_128_GCM",
         "SRTP_AES128_CM_HMAC_SHA1_80",
         "SRTP_AES128_CM_HMAC_SHA1_32"
     ]
+
+    # The engine (cryptographic provider) to use for SRTP cryptography.
+    # Valid values are "OpenSSL", "SunJCE", "SunPKCS11", "BouncyCastle",
+    # or null to let the implementation pick the provider at runtime.
+    # "OpenSSL" is currently only supported on Linux/x86_64.
+    # Custom class values are also possible - see Aes.setFactoryClassName
+    # in jitsi-srtp for more details.
+    # Generally the best performance will be obtained by "OpenSSL" on Linux/x86_64,
+    # and "SunJCE" otherwise, but see the logs for the measured performance of
+    # each provider.
+    factory-class="OpenSSL"
   }
   audio {
     red {


### PR DESCRIPTION
Note that this needs https://github.com/jitsi/jitsi-srtp/pull/26 in order to work correctly on platforms where the "OpenSSL" factory doesn't work (i.e. other than Linux/x86_64).