### PR TITLE
 Move tccEngine from Transceiver to RtpSender.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.srtp.SrtpTransformers
 import org.jitsi.nlj.stats.EndpointConnectionStats
 import org.jitsi.nlj.stats.PacketStreamStats
@@ -40,4 +41,6 @@ abstract class RtpSender :
     abstract fun getPacketStreamStats(): PacketStreamStats.Snapshot
     abstract fun requestKeyframe(mediaSsrc: Long? = null)
     abstract fun tearDown()
+
+    abstract val bandwidthEstimator: BandwidthEstimator
 }

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -26,6 +26,8 @@ import org.jitsi.nlj.rtcp.NackHandler
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtcp.RtcpSrUpdater
 import org.jitsi.nlj.rtp.TransportCcEngine
+import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
+import org.jitsi.nlj.rtp.bandwidthestimation.GoogleCcEstimator
 import org.jitsi.nlj.srtp.SrtpTransformers
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.NodeEventVisitor
@@ -60,7 +62,6 @@ import org.jitsi.nlj.util.BufferPool
 
 class RtpSenderImpl(
     val id: String,
-    val transportCcEngine: TransportCcEngine? = null,
     private val rtcpEventNotifier: RtcpEventNotifier,
     /**
      * The executor this class will use for its primary work (i.e. critical path
@@ -97,6 +98,8 @@ class RtpSenderImpl(
     // a generic handler here and then the bridge can put it into its PacketQueue and have
     // its handler (likely in another thread) grab the packet and send it out
     private var outgoingPacketHandler: PacketHandler? = null
+    override val bandwidthEstimator: BandwidthEstimator = GoogleCcEstimator(diagnosticContext, logger)
+    private val transportCcEngine = TransportCcEngine(bandwidthEstimator, logger)
 
     private val srtpEncryptWrapper = SrtpEncryptNode()
     private val srtcpEncryptWrapper = SrtcpEncryptNode()
@@ -148,6 +151,7 @@ class RtpSenderImpl(
 
         nackHandler = NackHandler(outgoingPacketCache.getPacketCache(), outgoingRtxRoot, logger)
         rtcpEventNotifier.addRtcpEventListener(nackHandler)
+        rtcpEventNotifier.addRtcpEventListener(transportCcEngine)
 
         // TODO: are we setting outgoing rtcp sequence numbers correctly? just add a simple node here to rewrite them
         outgoingRtcpRoot = pipeline {
@@ -264,6 +268,8 @@ class RtpSenderImpl(
         addString("running", running.toString())
         addString("localVideoSsrc", localVideoSsrc?.toString() ?: "null")
         addString("localAudioSsrc", localAudioSsrc?.toString() ?: "null")
+        addJson("transportCcEngine", transportCcEngine.getStatistics().toJson())
+        addJson("Bandwidth Estimation", bandwidthEstimator.getStats().toJson())
     }
 
     override fun stop() {

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
@@ -27,6 +27,7 @@ import org.jitsi.nlj.util.bps
 import org.jitsi.nlj.util.formatMilli
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
+import java.time.Clock
 
 /**
  * An abstract interface to a bandwidth estimation algorithm.
@@ -210,7 +211,7 @@ abstract class BandwidthEstimator(
      *
      * @param[now] The current time, when this function is called.
      */
-    abstract fun getStats(now: Instant): StatisticsSnapshot
+    abstract fun getStats(now: Instant = Clock.systemUTC().instant()): StatisticsSnapshot
 
     /** Reset the estimator to its initial state. */
     abstract fun reset(): Unit

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
@@ -63,9 +63,8 @@ abstract class BandwidthEstimator(
      * Inform the bandwidth estimator about a packet that has arrived at its
      * destination.
      *
-     * This function will be called at most once for any value of [seq];
-     * however, it may be called after a call to [processPacketLoss] for the
-     * same [seq] value, if a packet is delayed.
+     * This function will be called at most once for any value of [seq]; however, it may be called after a call to
+     * [processPacketLoss] for the same [seq] value, if a packet is delayed.
      *
      * It is possible (e.g., if feedback was lost) that neither
      * [processPacketArrival] nor [processPacketLoss] is called for a given [seq].

--- a/src/test/kotlin/org/jitsi/nlj/module_tests/SenderFactory.kt
+++ b/src/test/kotlin/org/jitsi/nlj/module_tests/SenderFactory.kt
@@ -47,7 +47,6 @@ class SenderFactory {
             val streamInformationStore = StreamInformationStoreImpl()
             val sender = RtpSenderImpl(
                 Random().nextLong().toString(),
-                null,
                 RtcpEventNotifier(),
                 executor,
                 backgroundExecutor,


### PR DESCRIPTION
This is just cleanup. The TCC engine was initially in `Transceiver` because it had ties to both `RtpSender` and `RtpReceiver`, but this is no longer the case, and it's logical place is `RtpSender`.