### PR TITLE
Feat: Include incoming and outgoing stream stats in node stats.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -271,6 +271,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
 
     override fun getNodeStats(): NodeStatsBlock = NodeStatsBlock("RTP receiver $id").apply {
         addBlock(super.getNodeStats())
+        addJson("incoming streams", statsTracker.getSnapshot().toJson())
         addString("running", running.toString())
         NodeStatsVisitor(this).visit(inputTreeRoot)
     }

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -278,6 +278,7 @@ class RtpSenderImpl(
         addString("running", running.toString())
         addString("localVideoSsrc", localVideoSsrc?.toString() ?: "null")
         addString("localAudioSsrc", localAudioSsrc?.toString() ?: "null")
+        addJson("outgoing streams", statsTracker.getSnapshot().toJson())
         addJson("transportCcEngine", transportCcEngine.getStatistics().toJson())
         addJson("Bandwidth Estimation", bandwidthEstimator.getStats().toJson())
     }


### PR DESCRIPTION
This includes the same information in debug stats as would be included by https://github.com/jitsi/jitsi-videobridge/pull/1532, without redundantly including some information more than once.