### PR TITLE
Refactor endpoint feature API

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/Event.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Event.kt
@@ -24,5 +24,3 @@ class SetMediaSourcesEvent(val mediaSourceDescs: Array<MediaSourceDesc>) : Event
 class SetLocalSsrcEvent(val mediaType: MediaType, val ssrc: Long) : Event
 
 class BandwidthEstimationChangedEvent(val bandwidthBps: Long) : Event
-
-class FeatureToggleEvent(val feature: Features, val enable: Boolean) : Event

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
@@ -53,6 +53,8 @@ abstract class RtpReceiver :
     abstract fun isReceivingAudio(): Boolean
     abstract fun isReceivingVideo(): Boolean
 
+    abstract fun setFeature(feature: Features, enabled: Boolean)
+
     /**
      * Forcibly mute or unmute the incoming audio stream
      */

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
@@ -54,6 +54,7 @@ abstract class RtpReceiver :
     abstract fun isReceivingVideo(): Boolean
 
     abstract fun setFeature(feature: Features, enabled: Boolean)
+    abstract fun isFeatureEnabled(feature: Features): Boolean
 
     /**
      * Forcibly mute or unmute the incoming audio stream

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -314,6 +314,12 @@ class RtpReceiverImpl @JvmOverloads constructor(
         }
     }
 
+    override fun isFeatureEnabled(feature: Features): Boolean {
+        return when (feature) {
+            Features.TRANSCEIVER_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
+        }
+    }
+
     override fun stop() {
         running = false
         rtcpRrGenerator.running = false

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -302,6 +302,18 @@ class RtpReceiverImpl @JvmOverloads constructor(
         audioLevelReader.forceMute = shouldMute
     }
 
+    override fun setFeature(feature: Features, enabled: Boolean) {
+        when (feature) {
+            Features.TRANSCEIVER_PCAP_DUMP -> {
+                if (enabled) {
+                    toggleablePcapWriter.enable()
+                } else {
+                    toggleablePcapWriter.disable()
+                }
+            }
+        }
+    }
+
     override fun stop() {
         running = false
         rtcpRrGenerator.running = false

--- a/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
@@ -43,6 +43,7 @@ abstract class RtpSender :
     abstract fun getTransportCcEngineStats(): TransportCcEngine.StatisticsSnapshot
     abstract fun requestKeyframe(mediaSsrc: Long? = null)
     abstract fun setFeature(feature: Features, enabled: Boolean)
+    abstract fun isFeatureEnabled(feature: Features): Boolean
     abstract fun tearDown()
 
     abstract val bandwidthEstimator: BandwidthEstimator

--- a/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
@@ -42,6 +42,7 @@ abstract class RtpSender :
     abstract fun getPacketStreamStats(): PacketStreamStats.Snapshot
     abstract fun getTransportCcEngineStats(): TransportCcEngine.StatisticsSnapshot
     abstract fun requestKeyframe(mediaSsrc: Long? = null)
+    abstract fun setFeature(feature: Features, enabled: Boolean)
     abstract fun tearDown()
 
     abstract val bandwidthEstimator: BandwidthEstimator

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -229,6 +229,18 @@ class RtpSenderImpl(
         keyframeRequester.requestKeyframe(mediaSsrc)
     }
 
+    override fun setFeature(feature: Features, enabled: Boolean) {
+        when (feature) {
+            Features.TRANSCEIVER_PCAP_DUMP -> {
+                if (enabled) {
+                    toggleablePcapWriter.enable()
+                } else {
+                    toggleablePcapWriter.disable()
+                }
+            }
+        }
+    }
+
     /**
      * Handles packets that have gone through the incoming queue and sends them
      * through the sender pipeline

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -241,6 +241,12 @@ class RtpSenderImpl(
         }
     }
 
+    override fun isFeatureEnabled(feature: Features): Boolean {
+        return when (feature) {
+            Features.TRANSCEIVER_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
+        }
+    }
+
     /**
      * Handles packets that have gone through the incoming queue and sends them
      * through the sender pipeline

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -319,9 +319,8 @@ class Transceiver(
     }
 
     fun setFeature(feature: Features, enabled: Boolean) {
-        val featureToggleEvent = FeatureToggleEvent(feature, enabled)
-        rtpReceiver.handleEvent(featureToggleEvent)
-        rtpSender.handleEvent(featureToggleEvent)
+        rtpReceiver.setFeature(feature, enabled)
+        rtpSender.setFeature(feature, enabled)
     }
 
     companion object {

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -323,6 +323,14 @@ class Transceiver(
         rtpSender.setFeature(feature, enabled)
     }
 
+    fun isFeatureEnabled(feature: Features): Boolean {
+        // As of now, the only feature we have (pcap) is always enabled on both
+        // the RTP sender and RTP receiver at the same time, so returning
+        // the state of one of them is sufficient.  If that were to change
+        // in the future we'd have to rethink this API
+        return rtpReceiver.isFeatureEnabled(feature)
+    }
+
     companion object {
         init {
 //            Node.plugins.add(BufferTracePlugin)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -18,12 +18,8 @@ package org.jitsi.nlj.transform.node
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
-import org.jitsi.nlj.Event
-import org.jitsi.nlj.FeatureToggleEvent
-import org.jitsi.nlj.Features
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.utils.logging2.Logger
-import java.lang.IllegalStateException
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
 
@@ -50,20 +46,6 @@ class ToggleablePcapWriter(
     private inner class PcapWriterNode(name: String) : ObserverNode(name) {
         override fun observe(packetInfo: PacketInfo) {
             pcapWriter.get()?.processPacket(packetInfo)
-        }
-
-        override fun handleEvent(event: Event) {
-            when (event) {
-                is FeatureToggleEvent -> {
-                    if (event.feature == Features.TRANSCEIVER_PCAP_DUMP) {
-                        if (event.enable) {
-                            enable()
-                        } else {
-                            disable()
-                        }
-                    }
-                }
-            }
         }
 
         override fun trace(f: () -> Unit) = f.invoke()

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -38,7 +38,7 @@ class ToggleablePcapWriter(
     }
 
     fun disable() {
-        pcapWriter.set(null)
+        pcapWriter.getAndSet(null)?.close()
     }
 
     fun isEnabled(): Boolean = pcapWriter.get() != null

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -41,6 +41,8 @@ class ToggleablePcapWriter(
         pcapWriter.set(null)
     }
 
+    fun isEnabled(): Boolean = pcapWriter.get() != null
+
     fun newObserverNode(): Node = PcapWriterNode("Toggleable pcap writer: $prefix")
 
     private inner class PcapWriterNode(name: String) : ObserverNode(name) {

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -54,6 +54,6 @@ class ToggleablePcapWriter(
     }
 
     companion object {
-        val allowed: Boolean by config("jmt.debug.pcap.enabled".from(JitsiConfig.newConfig))
+        private val allowed: Boolean by config("jmt.debug.pcap.enabled".from(JitsiConfig.newConfig))
     }
 }

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -30,7 +30,7 @@ class ToggleablePcapWriter(
     private val pcapWriter = AtomicReference<PcapWriter?>(null)
 
     fun enable() {
-        if (!enabled) {
+        if (!allowed) {
             throw IllegalStateException("PCAP capture is disabled in configuration")
         }
 
@@ -52,6 +52,6 @@ class ToggleablePcapWriter(
     }
 
     companion object {
-        val enabled: Boolean by config("jmt.debug.pcap.enabled".from(JitsiConfig.newConfig))
+        val allowed: Boolean by config("jmt.debug.pcap.enabled".from(JitsiConfig.newConfig))
     }
 }


### PR DESCRIPTION
The old endpoint feature API used a `FeatureToggle` message that was sent through the pipeline for nodes to handle, but this makes querying the state of features very awkward.  This PR changes the API to use an explicit `setFeature` method, and also exposes an `isFeatureEnabled` method.  The main driver behind these changes was to make them friendlier to use in the jvb dashboard.  There are accompanying JVB changes that need to be made as well.