### PR TITLE
fix: Synchronize access to RED packet cache.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -185,9 +185,12 @@ class RtpSenderImpl(
         }
 
         probingDataSender = ProbingDataSender(
-            outgoingPacketCache.getPacketCache(), outgoingRtxRoot, absSendTime, diagnosticContext,
-            streamInformationStore,
-            logger
+            packetCache = outgoingPacketCache.getPacketCache(),
+            rtxDataSender = outgoingRtxRoot,
+            garbageDataSender = absSendTime,
+            diagnosticContext = diagnosticContext,
+            streamInformationStore = streamInformationStore,
+            parentLogger = logger
         )
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
@@ -93,8 +93,9 @@ class AudioRedHandler(
         /**
          * Saves audio (non-RED) packets that we've sent. Packets are cloned on insert and the inserted copies are owned
          * by the cache, meaning that the cache is responsible for returning their buffers to the pool.
+         * It needs to be synchronized because [stop] and [transformAudio] may run in different threads.
          */
-        val sentAudioCache = RtpPacketCache(20, synchronize = false)
+        val sentAudioCache = RtpPacketCache(20, synchronize = true)
 
         /**
          * Process an incoming audio packet. It is either forwarded as it is, or encapsulated in RED with previous


### PR DESCRIPTION
Fixes a potential double return to the buffer pool if `insert` and `flush` run together.