### PR TITLE
Added mute video moderation feature

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
@@ -60,6 +60,8 @@ abstract class RtpReceiver :
      * Forcibly mute or unmute the incoming audio stream
      */
     abstract fun forceMuteAudio(shouldMute: Boolean)
+
+    abstract fun forceMuteVideo(shouldMute: Boolean)
 }
 
 interface RtpReceiverEventHandler {

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -55,6 +55,7 @@ import org.jitsi.nlj.transform.node.incoming.TccGeneratorNode
 import org.jitsi.nlj.transform.node.incoming.VideoBitrateCalculator
 import org.jitsi.nlj.transform.node.incoming.VideoParser
 import org.jitsi.nlj.transform.node.incoming.Vp8Parser
+import org.jitsi.nlj.transform.node.incoming.VideoMuteNode
 import org.jitsi.nlj.transform.packetPath
 import org.jitsi.nlj.transform.pipeline
 import org.jitsi.nlj.util.PacketInfoQueue
@@ -118,6 +119,9 @@ class RtpReceiverImpl @JvmOverloads constructor(
             }
         }
     }
+
+    private val videoMuteNode = VideoMuteNode()
+
     private val silenceDiscarder = DiscardableDiscarder("Silence discarder", false)
     private val paddingOnlyDiscarder = DiscardableDiscarder("Padding-only discarder", true)
     private val statsTracker = IncomingStatisticsTracker(streamInformationStore)
@@ -210,6 +214,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
                         // audioLevelReader back to where it was (in the audio path) and add a new node here which would
                         // check for different discard conditions (i.e. checking the audio level for silence)
                         node(audioLevelReader)
+                        node(videoMuteNode)
                         node(srtpDecryptWrapper)
                         node(toggleablePcapWriter.newObserverNode())
                         node(statsTracker)
@@ -300,6 +305,10 @@ class RtpReceiverImpl @JvmOverloads constructor(
 
     override fun forceMuteAudio(shouldMute: Boolean) {
         audioLevelReader.forceMute = shouldMute
+    }
+
+    override fun forceMuteVideo(shouldMute: Boolean) {
+        videoMuteNode.forceMute = shouldMute
     }
 
     override fun setFeature(feature: Features, enabled: Boolean) {

--- a/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -279,6 +279,14 @@ class Transceiver(
         rtpReceiver.forceMuteAudio(shouldMute)
     }
 
+    fun forceMuteVideo(shouldMute: Boolean) {
+        when (shouldMute) {
+            true -> logger.info("Muting incoming video")
+            false -> logger.info("Unmuting incoming video")
+        }
+        rtpReceiver.forceMuteVideo(shouldMute)
+    }
+
     /**
      * Get stats about this transceiver's pipeline nodes
      */

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoMuteNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoMuteNode.kt
@@ -1,0 +1,26 @@
+package org.jitsi.nlj.transform.node.incoming
+
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.rtp.VideoRtpPacket
+import org.jitsi.nlj.stats.NodeStatsBlock
+import org.jitsi.nlj.transform.node.ObserverNode
+
+class VideoMuteNode : ObserverNode("Video mute node") {
+
+    private var numMutedPackets = 0
+    var forceMute: Boolean = false
+
+    override fun observe(packetInfo: PacketInfo) {
+        val videoRtpPacket = packetInfo.packet as? VideoRtpPacket ?: return
+        if (this.forceMute) {
+            packetInfo.shouldDiscard = true
+            numMutedPackets++
+        }
+    }
+
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_video_packets_discarded", numMutedPackets)
+    }
+
+    override fun trace(f: () -> Unit) = f.invoke()
+}


### PR DESCRIPTION
This change adds the ability for a moderator to deactivate the camera of other participants. The implementation uses the same approach that was implemented to mute audio of other participants.

This feature consists of multiple PRs:
- https://github.com/jitsi/jitsi-media-transform/pull/329
- https://github.com/jitsi/jitsi-videobridge/pull/1570
- https://github.com/jitsi/jitsi-xmpp-extensions/pull/37
- https://github.com/jitsi/jicofo/pull/695
- https://github.com/jitsi/lib-jitsi-meet/pull/1496
- https://github.com/jitsi/jitsi-meet/pull/8630