### PR TITLE
remove buffers from queue as we return them in DtlsStack#close

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -279,14 +279,14 @@ class DtlsStack(
 
         override fun receive(buf: ByteArray, off: Int, len: Int, waitMillis: Int): Int {
             val data = synchronized(lock) {
-                if (!running || this@DtlsStack.incomingProtocolData.isEmpty()) {
+                if (!running || incomingProtocolData.isEmpty()) {
                     return -1
                 }
                 // Note: we don't use the timeout values here because we don't actually need them.  We add a buffer
                 // into this queue above and then call a method which will pull it through via this method.  The
                 // only reason waitMillis exists is because the BouncyCastle DatagramTransport interface this class
                 // implements defines it that way.
-                this@DtlsStack.incomingProtocolData.removeFirst()
+                incomingProtocolData.removeFirst()
             }
             val length = min(len, data.limit())
             if (length < data.limit()) {
@@ -301,7 +301,7 @@ class DtlsStack(
         }
 
         override fun send(buf: ByteArray, off: Int, len: Int) {
-            this@DtlsStack.outgoingDataHandler?.sendData(buf, off, len)
+            outgoingDataHandler?.sendData(buf, off, len)
         }
 
         /**

--- a/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -151,7 +151,6 @@ class DtlsStack(
         roleSet.await()
         synchronized(lock) {
             running = true
-            // TODO: could updating dtlsTransport in this lock solve the issue below?
         }
 
         dtlsTransport = role?.start()

--- a/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -160,8 +160,9 @@ class DtlsStack(
 
     fun close() {
         datagramTransport.close()
-        incomingProtocolData.forEach {
-            BufferPool.returnBuffer(it.array())
+        while (incomingProtocolData.isNotEmpty()) {
+            val buf = incomingProtocolData.poll() ?: break
+            BufferPool.returnBuffer(buf.array())
         }
     }
 

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import kotlin.concurrent.thread
 
-@ExperimentalStdlibApi
 class DtlsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
     private val debugEnabled = true

--- a/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import kotlin.concurrent.thread
 
+@ExperimentalStdlibApi
 class DtlsTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
     private val debugEnabled = true


### PR DESCRIPTION
This PR fixes a double buffer return when `DtlsStack#close` races with `DatagramTransportImpl#receive`.  The issue is that `DtlsStack#close` iterates over the buffers in the queue and returns them, but doesn't remove them from the queue.  This means a future call to `DatagramTransportImpl#receive` can still process one of those buffers and return it (again).

I considered also putting an `running` flag in `DatagramTransportImpl` that we would set to `false` in `close` and read in `receive`, but that alone wouldn't be enough to address this since the `receive` method could already be in progress when `close` is called.  It might still be a good idea, though, and I'm open to it--I just didn't do it since it wouldn't solve the problem by itself.

The `incomingProtocolData.isNotEmpty()` guard in the while also feels a bit weird, since the result of `poll` is the main source of truth there.  I thought about making it `while(true)` and relying on `poll` returning null, but `while(true)` felt a little scary so I left with the `isNotEmpty` check.

I believe this should fix the double return, but after looking at this code I think it can still leak: there's nothing to prevent another buffer from being added into the queue (via `processIncomingProtocolData`) after `close` has been called so either: 1) `receive` will be called and will 'pull' the buffer through the queue and take care of it or 2) the objects will be freed up and garbage collected.  To address this I think we'd need both a `running` flag and a lock to make sure checks to `running` and accesses of the queue were atomic.  Will think about that some more and either add something to this PR or create another.