### PR TITLE
StreamInformation: optimize supportsTcc/Remb/Pli calculation.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
@@ -158,9 +158,9 @@ class StreamInformationStoreImpl : StreamInformationStore {
     override fun addRtpPayloadType(payloadType: PayloadType) {
         synchronized(payloadTypesLock) {
             _rtpPayloadTypes[payloadType.pt] = payloadType
-            supportsPli = rtpPayloadTypes.values.find { it.rtcpFeedbackSet.supportsPli() } != null
-            supportsRemb = rtpPayloadTypes.values.find { it.rtcpFeedbackSet.supportsRemb() } != null
-            supportsTcc = rtpPayloadTypes.values.find { it.rtcpFeedbackSet.supportsTcc() } != null
+            supportsPli = supportsPli || payloadType.rtcpFeedbackSet.supportsPli()
+            supportsRemb = supportsRemb || payloadType.rtcpFeedbackSet.supportsRemb()
+            supportsTcc = supportsTcc || payloadType.rtcpFeedbackSet.supportsTcc()
             payloadTypeHandlers.forEach { it(_rtpPayloadTypes) }
         }
     }


### PR DESCRIPTION
I noticed this when we were trying to track down performance issues.  In retrospect I don't think it's actually a substantial amount of time, but it seems obvious.