### PR TITLE
Change Bandwidth to an inline class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
                 </executions>
                 <configuration>
                     <jvmTarget>1.8</jvmTarget>
+                    <args>
+                        <arg>-Xinline-classes</arg>
+                    </args>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -222,7 +222,7 @@ public class RemoteBitrateEstimatorAbsSendTime
         // should be broken out from  here.
         // Check if incoming bitrate estimate is valid, and if it
         // needs to be reset.
-        long incomingBitrate_ = (long) incomingBitrate.getRate(arrivalTimeMs).getBps();
+        long incomingBitrate_ = incomingBitrate.getRateBps(arrivalTimeMs);
         if (incomingBitrate_ != 0)
         {
             incomingBitrateInitialized = true;
@@ -286,7 +286,7 @@ public class RemoteBitrateEstimatorAbsSendTime
         else if (
             detector.detector.getState() == BandwidthUsage.kBwOverusing)
         {
-            long incomingRate_ = (long) incomingBitrate.getRate(arrivalTimeMs).getBps();
+            long incomingRate_ = incomingBitrate.getRateBps(arrivalTimeMs);
 
             if (incomingRate_ > 0 && remoteRate
                 .isTimeToReduceFurther(nowMs, incomingBitrate_))
@@ -302,7 +302,7 @@ public class RemoteBitrateEstimatorAbsSendTime
             // overusing and the target bitrate is too high compared to
             // what we are receiving.
             input.bwState = detector.detector.getState();
-            input.incomingBitRate = (long) incomingBitrate.getRate(arrivalTimeMs).getBps();
+            input.incomingBitRate = incomingBitrate.getRateBps(arrivalTimeMs);
             input.noiseVar = detector.estimator.getVarNoise();
 
             remoteRate.update(input, nowMs);

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -15,13 +15,13 @@
  */
 package org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation;
 
-import org.jetbrains.annotations.*;
+import org.jetbrains.annotations.NotNull;
 import org.jitsi.utils.logging.DiagnosticContext;
 import org.jitsi.utils.logging.TimeSeriesLogger;
-import org.jitsi.utils.logging2.*;
+import org.jitsi.utils.logging2.Logger;
 import org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation.config.SendSideBandwidthEstimationConfig;
 
-import java.time.*;
+import java.time.Duration;
 import java.util.*;
 
 /**
@@ -225,13 +225,13 @@ public class SendSideBandwidthEstimation
         {
             low_loss_threshold_ = SendSideBandwidthEstimationConfig.experimentalLowLossThreshold();
             high_loss_threshold_ = SendSideBandwidthEstimationConfig.experimentalHighLossThreshold();
-            bitrate_threshold_bps_ = (int) SendSideBandwidthEstimationConfig.experimentalBitrateThreshold().getBps();
+            bitrate_threshold_bps_ = (int) SendSideBandwidthEstimationConfig.experimentalBitrateThresholdBps();
         }
         else
         {
             low_loss_threshold_ = SendSideBandwidthEstimationConfig.defaultLowLossThreshold();
             high_loss_threshold_ = SendSideBandwidthEstimationConfig.defaultHighLossThreshold();
-            bitrate_threshold_bps_ = (int) SendSideBandwidthEstimationConfig.defaultBitrateThreshold().getBps();
+            bitrate_threshold_bps_ = (int) SendSideBandwidthEstimationConfig.defaultBitrateThresholdBps();
         }
 
 

--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -108,11 +108,11 @@ val Float.mbps: Bandwidth
     get() = Bandwidth(this.toDouble() * 1000 * 1000)
 
 val Double.bps: Bandwidth
-    get() = Bandwidth(this.toDouble())
+    get() = Bandwidth(this)
 val Double.kbps: Bandwidth
-    get() = Bandwidth(this.toDouble() * 1000)
+    get() = Bandwidth(this * 1000)
 val Double.mbps: Bandwidth
-    get() = Bandwidth(this.toDouble() * 1000 * 1000)
+    get() = Bandwidth(this * 1000 * 1000)
 
 val Long.bps: Bandwidth
     get() = Bandwidth(this.toDouble())

--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -25,8 +25,10 @@ import kotlin.math.sign
  * of bits per second.
  */
 inline class Bandwidth(val bps: Double) : Comparable<Bandwidth> {
-    fun kbps(): Double = bps / 1000
-    fun mbps(): Double = bps / (1000 * 1000)
+    val kbps: Double
+        get() = bps / 1000
+    val mbps: Double
+        get() = bps / (1000 * 1000)
 
     operator fun minus(other: Bandwidth): Bandwidth =
         Bandwidth(bps - other.bps)
@@ -71,8 +73,8 @@ inline class Bandwidth(val bps: Double) : Comparable<Bandwidth> {
         // in the ones place
         val format = DecimalFormat("0.##")
         return when {
-            mbps() >= 1 -> "${format.format(mbps())} mbps"
-            kbps() >= 1 -> "${format.format(kbps())} kbps"
+            mbps >= 1 -> "${format.format(mbps)} mbps"
+            kbps >= 1 -> "${format.format(kbps)} kbps"
             else -> "${format.format(bps)} bps"
         }
     }

--- a/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -24,11 +24,9 @@ import kotlin.math.sign
  * [Bandwidth] models a current bandwidth, represented as a rate
  * of bits per second.
  */
-class Bandwidth(bps: Double) : Comparable<Bandwidth> {
-    val bps: Double = bps
-
-    val kbps: Double = bps / 1000
-    val mbps: Double = bps / (1000 * 1000)
+inline class Bandwidth(val bps: Double) : Comparable<Bandwidth> {
+    fun kbps(): Double = bps / 1000
+    fun mbps(): Double = bps / (1000 * 1000)
 
     operator fun minus(other: Bandwidth): Bandwidth =
         Bandwidth(bps - other.bps)
@@ -73,27 +71,17 @@ class Bandwidth(bps: Double) : Comparable<Bandwidth> {
         // in the ones place
         val format = DecimalFormat("0.##")
         return when {
-            mbps >= 1 -> "${format.format(mbps)} mbps"
-            kbps >= 1 -> "${format.format(kbps)} kbps"
+            mbps() >= 1 -> "${format.format(mbps())} mbps"
+            kbps() >= 1 -> "${format.format(kbps())} kbps"
             else -> "${format.format(bps)} bps"
         }
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (other !is Bandwidth) {
-            return false
-        }
-        return compareTo(other) == 0
-    }
-
-    override fun hashCode(): Int = bps.hashCode()
 
     companion object {
         fun fromString(str: String): Bandwidth {
             val (digits, notDigits) = str.partition { it.isDigit() }
             val amount = digits.toInt()
-            val unit = notDigits.trim().toLowerCase()
-            return when (unit) {
+            return when (val unit = notDigits.trim().toLowerCase()) {
                 "bps" -> amount.bps
                 "kbps" -> amount.kbps
                 "mbps" -> amount.mbps

--- a/src/main/kotlin/org/jitsi/nlj/util/BitrateTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/BitrateTracker.kt
@@ -29,6 +29,7 @@ open class BitrateTracker @JvmOverloads constructor(
     // that RateTracker uses.
     private val tracker = RateTracker(windowSize, bucketSize, clock)
     open fun getRate(nowMs: Long = clock.millis()): Bandwidth = tracker.getRate(nowMs).bps
+    open fun getRateBps(nowMs: Long = clock.millis()): Long = tracker.getRate(nowMs)
     val rate: Bandwidth
         get() = getRate()
     fun update(dataSize: DataSize, now: Long = clock.millis()) = tracker.update(dataSize.bits, now)

--- a/src/main/kotlin/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/config/SendSideBandwidthEstimationConfig.kt
+++ b/src/main/kotlin/org/jitsi_modified/impl/neomedia/rtp/sendsidebandwidthestimation/config/SendSideBandwidthEstimationConfig.kt
@@ -54,6 +54,9 @@ class SendSideBandwidthEstimationConfig {
         @JvmStatic
         fun defaultBitrateThreshold() = defaultBitrateThreshold
 
+        @JvmStatic
+        fun defaultBitrateThresholdBps() = defaultBitrateThreshold.bps
+
         private const val LEGACY_BASE_NAME =
             "org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation.SendSideBandwidthEstimation"
 
@@ -102,6 +105,9 @@ class SendSideBandwidthEstimationConfig {
          */
         @JvmStatic
         fun experimentalBitrateThreshold() = experimentalBitrateThreshold
+
+        @JvmStatic
+        fun experimentalBitrateThresholdBps() = experimentalBitrateThreshold.bps
 
         private val timeoutExperimentProbability: Double by config {
             "$LEGACY_BASE_NAME.timeoutExperimentProbability".from(JitsiConfig.legacyConfig)

--- a/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -236,4 +236,8 @@ private class FakeBitrateTracker(
     override fun getRate(nowMs: Long): Bandwidth {
         return fakeRateBps.bps
     }
+
+    override fun getRateBps(nowMs: Long): Long {
+        return fakeRateBps
+    }
 }

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -46,25 +46,25 @@ class BandwidthTest : ShouldSpec() {
                 var b = 1.mbps
                 b += 0.5.mbps
                 b shouldBe 1.5.mbps
-                b.kbps() shouldBe 1500.0
+                b.kbps shouldBe 1500.0
                 b.bps shouldBe 1_500_000.0
 
                 b = 1.mbps
                 b -= 0.5.mbps
                 b shouldBe 0.5.mbps
-                b.kbps() shouldBe 500.0
+                b.kbps shouldBe 500.0
                 b.bps shouldBe 500_000.0
 
                 b = 1.mbps
                 b *= 2.0
                 b shouldBe 2.0.mbps
-                b.kbps() shouldBe 2_000.0
+                b.kbps shouldBe 2_000.0
                 b.bps shouldBe 2_000_000.0
 
                 b = 1.mbps
                 b /= 2.0
                 b shouldBe 0.5.mbps
-                b.kbps() shouldBe 500.0
+                b.kbps shouldBe 500.0
                 b.bps shouldBe 500_000.0
             }
         }

--- a/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/BandwidthTest.kt
@@ -46,25 +46,25 @@ class BandwidthTest : ShouldSpec() {
                 var b = 1.mbps
                 b += 0.5.mbps
                 b shouldBe 1.5.mbps
-                b.kbps shouldBe 1500.0
+                b.kbps() shouldBe 1500.0
                 b.bps shouldBe 1_500_000.0
 
                 b = 1.mbps
                 b -= 0.5.mbps
                 b shouldBe 0.5.mbps
-                b.kbps shouldBe 500.0
+                b.kbps() shouldBe 500.0
                 b.bps shouldBe 500_000.0
 
                 b = 1.mbps
                 b *= 2.0
                 b shouldBe 2.0.mbps
-                b.kbps shouldBe 2_000.0
+                b.kbps() shouldBe 2_000.0
                 b.bps shouldBe 2_000_000.0
 
                 b = 1.mbps
                 b /= 2.0
                 b shouldBe 0.5.mbps
-                b.kbps shouldBe 500.0
+                b.kbps() shouldBe 500.0
                 b.bps shouldBe 500_000.0
             }
         }


### PR DESCRIPTION
We found that there were lots of allocations of the `Bandwidth` class when doing testing of large calls; changing it to an inline class saves a lot of allocations.  JVB changes here: https://github.com/jitsi/jitsi-videobridge/pull/1593