### PR TITLE
Mark layeringChanged when a layer becomes active.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -140,10 +140,13 @@ constructor(
      *
      * @param packetSize
      * @param nowMs
+     * @return true if this caused the rate being tracked to transition from zero to nonzero
      */
-    fun updateBitrate(packetSize: DataSize, nowMs: Long) {
+    fun updateBitrate(packetSize: DataSize, nowMs: Long): Boolean {
+        val wasInactive = bitrateTracker.getAccumulatedSize(nowMs).bits == 0L
         // Update rate stats (this should run after padding termination).
         bitrateTracker.update(packetSize, nowMs)
+        return wasInactive && packetSize.bits > 0L
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
@@ -57,7 +57,12 @@ class VideoBitrateCalculator(
         val videoRtpPacket: VideoRtpPacket = packetInfo.packet as VideoRtpPacket
         mediaSourceDescs.findRtpLayerDesc(videoRtpPacket)?.let {
             val now = System.currentTimeMillis()
-            it.updateBitrate(videoRtpPacket.length.bytes, now)
+            if (it.updateBitrate(videoRtpPacket.length.bytes, now)) {
+                /* When a layer is started when it was previously inactive,
+                 * we want to recalculate bandwidth allocation.
+                 */
+                packetInfo.layeringChanged = true
+            }
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/util/BitrateTracker.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/BitrateTracker.kt
@@ -33,5 +33,5 @@ open class BitrateTracker @JvmOverloads constructor(
     val rate: Bandwidth
         get() = getRate()
     fun update(dataSize: DataSize, now: Long = clock.millis()) = tracker.update(dataSize.bits, now)
-    fun getAccumulatedSize(now: Long = clock.millis()) = tracker.getAccumulatedCount(now).bps
+    fun getAccumulatedSize(now: Long = clock.millis()) = tracker.getAccumulatedCount(now).bits
 }


### PR DESCRIPTION
This should fix the issue in JVB that we don't switch sources to HD quickly when
they come out of layer-suspension.