### PR TITLE
Fix an IllegalStateException in ResumableStreamRewriter.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/ResumableStreamRewriter.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/ResumableStreamRewriter.kt
@@ -198,7 +198,7 @@ class ResumableStreamRewriter(val keepHistory: Boolean = false) {
                     /* Older than previous oldest, but still in range of the map.
                        Project map backwards. */
 
-                    val oldestIndex = Math.max(index - size, firstIndex)
+                    val oldestIndex = Math.max(lastIndex - size + 1, firstIndex)
                     val oldest = getContainer(oldestIndex)
                         ?: throw IllegalStateException("No oldest container found")
 
@@ -220,7 +220,7 @@ class ResumableStreamRewriter(val keepHistory: Boolean = false) {
                 else -> {
                     /* Older than the map. */
 
-                    val oldestIndex = Math.max(index - size, firstIndex)
+                    val oldestIndex = Math.max(lastIndex - size + 1, firstIndex)
                     val oldest = getContainer(oldestIndex)
                         ?: throw IllegalStateException("No oldest container found")
                     val oldestDelta = oldestIndex - oldest.item!!.newIndex

--- a/src/test/kotlin/org/jitsi/nlj/util/ResumableStreamRewriterTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/util/ResumableStreamRewriterTest.kt
@@ -259,6 +259,18 @@ internal class ResumableStreamRewriterTest : ShouldSpec() {
                     ret = snr.rewriteSequenceNumber(true, 0)
                     ret shouldBe 0xffff
                 }
+
+                context("Roll forward by the full gap") {
+                    for (seq in 5..1005) {
+                        ret = snr.rewriteSequenceNumber(true, seq)
+                        ret shouldBe seq - 3
+                    }
+                }
+
+                context("Accept packet older than wraparound.") {
+                    ret = snr.rewriteSequenceNumber(true, 3)
+                    ret shouldBe 0
+                }
             }
         }
     }


### PR DESCRIPTION
When a packet arrives that is newer than the oldest packet seen, but older than the
current history window.