### PR TITLE
Fix: Bump jitsi-srtp version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-srtp</artifactId>
-            <version>1.0-33-gfe519d1</version>
+            <version>1.1-2-gabdf3cc</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Hopefully will fix crash due to GC of native objects.