### PR TITLE
Copy all members in PacketInfo::clone()

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -145,8 +145,10 @@ open class PacketInfo @JvmOverloads constructor(
             PacketInfo(packet.clone(), timeline)
         }
         clone.receivedTime = receivedTime
-        clone.payloadVerification = payloadVerification
+        clone.shouldDiscard = shouldDiscard
+        clone.endpointId = endpointId
         clone.layeringChanged = layeringChanged
+        clone.payloadVerification = payloadVerification
         @Suppress("UNCHECKED_CAST") /* ArrayList.clone() really does return ArrayList, not Object. */
         clone.onSentActions = onSentActions?.clone() as ArrayList<()->Unit>?
         return clone


### PR DESCRIPTION
endpointId and shouldDiscard were not copied.