### PR TITLE
Remove hop-by-hop header extensions from sent RTP packets.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>rtp</artifactId>
-            <version>1.0-54-ge0d663c</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>rtp</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-58-g71521f9</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -44,10 +44,12 @@ import org.jitsi.nlj.transform.node.SrtcpEncryptNode
 import org.jitsi.nlj.transform.node.SrtpEncryptNode
 import org.jitsi.nlj.transform.node.ToggleablePcapWriter
 import org.jitsi.nlj.transform.node.outgoing.AbsSendTime
+import org.jitsi.nlj.transform.node.outgoing.HeaderExtEncoder
 import org.jitsi.nlj.transform.node.outgoing.OutgoingStatisticsTracker
 import org.jitsi.nlj.transform.node.outgoing.ProbingDataSender
 import org.jitsi.nlj.transform.node.outgoing.RetransmissionSender
 import org.jitsi.nlj.transform.node.outgoing.SentRtcpStats
+import org.jitsi.nlj.transform.node.outgoing.HeaderExtStripper
 import org.jitsi.nlj.transform.node.outgoing.TccSeqNumTagger
 import org.jitsi.nlj.transform.pipeline
 import org.jitsi.nlj.util.PacketInfoQueue
@@ -139,10 +141,12 @@ class RtpSenderImpl(
 
         outgoingRtpRoot = pipeline {
             node(AudioRedHandler(streamInformationStore))
+            node(HeaderExtStripper(streamInformationStore))
             node(outgoingPacketCache)
             node(absSendTime)
             node(statsTracker)
             node(TccSeqNumTagger(transportCcEngine, streamInformationStore))
+            node(HeaderExtEncoder())
             node(toggleablePcapWriter.newObserverNode())
             node(srtpEncryptWrapper)
             node(packetStreamStats.createNewNode())

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -29,8 +29,10 @@ class AbsSendTime(
     private var extensionId: Int? = null
 
     init {
-        streamInformationStore.onRtpExtensionMapping(ABS_SEND_TIME) {
-            extensionId = it
+        if (!streamInformationStore.supportsTcc) {
+            streamInformationStore.onRtpExtensionMapping(ABS_SEND_TIME) {
+                extensionId = it
+            }
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtEncoder.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtEncoder.kt
@@ -1,0 +1,17 @@
+package org.jitsi.nlj.transform.node.outgoing
+
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.transform.node.ModifierNode
+import org.jitsi.rtp.rtp.RtpPacket
+
+class HeaderExtEncoder : ModifierNode("Header extension encoder") {
+    override fun modify(packetInfo: PacketInfo): PacketInfo {
+        val rtpPacket = packetInfo.packetAs<RtpPacket>()
+
+        rtpPacket.encodeHeaderExtensions()
+
+        return packetInfo
+    }
+
+    override fun trace(f: () -> Unit) = f.invoke()
+}

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtEncoder.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtEncoder.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2018 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.nlj.transform.node.outgoing
 
 import org.jitsi.nlj.PacketInfo

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
@@ -1,0 +1,32 @@
+package org.jitsi.nlj.transform.node.outgoing
+
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.rtp.RtpExtensionType
+import org.jitsi.nlj.transform.node.ModifierNode
+import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
+import org.jitsi.rtp.rtp.RtpPacket
+
+/**
+ * Strip all hop-by-hop header extensions.  Currently this leaves only ssrc-audio-level.
+ */
+class HeaderExtStripper(
+    streamInformationStore: ReadOnlyStreamInformationStore
+) : ModifierNode("Strip header extensions") {
+    private var retainedExts: Set<Int> = emptySet()
+
+    init {
+        streamInformationStore.onRtpExtensionMapping(RtpExtensionType.SSRC_AUDIO_LEVEL) {
+            retainedExts = if (it != null) setOf(it) else emptySet()
+        }
+    }
+
+    override fun modify(packetInfo: PacketInfo): PacketInfo {
+        val rtpPacket = packetInfo.packetAs<RtpPacket>()
+
+        rtpPacket.removeHeaderExtensionsExcept(retainedExts)
+
+        return packetInfo
+    }
+
+    override fun trace(f: () -> Unit) = f.invoke()
+}

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2018 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.nlj.transform.node.outgoing
 
 import org.jitsi.nlj.PacketInfo

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -57,15 +57,7 @@ class TccSeqNumTagger(
 
                     currTccSeqNum++
                 }
-                else -> {
-                    rtpPacket.getHeaderExtension(tccExtId)?.let {
-                        // This is a hack: we don't want to do TCC for audio (since some browsers
-                        // don't support it) but we don't want to strip the existing extension
-                        // either (as its costly), so we merely change its ID to something we
-                        // know (based on Jicofo's offer) is unused.
-                        it.id = 14
-                    }
-                }
+                else -> Unit
             }
         }
 


### PR DESCRIPTION
Depends on https://github.com/jitsi/jitsi-rtp/pull/91.