### PR TITLE
fix: Expire the first incoming estimate after a period of inactivity.

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -64,6 +64,8 @@ class AimdRateControl
 
     private boolean bitrateIsInitialized;
 
+    private int incomingBitrateExpirations = 0;
+
     private long currentBitrateBps;
 
     private final RateControlInput currentInput
@@ -450,6 +452,23 @@ class AimdRateControl
                     {
                         timeFirstIncomingEstimate = -1L;
                     }
+
+                    // FIXME Where do we want to track the number of incoming
+                    // bitrate expirations (stored in the incomingBitrateExpirations
+                    // variable below)? The sum of this number across all AIMDs/bridges/deployments
+                    // will be the overall number of times we've prevented the ninjas
+                    // problem thanks to this patch. I see a couple of options:
+                    //
+                    // 1. The debug JSON output feels appropriate but that is not
+                    // something that is accessible/plottable in wavefront afaik.
+                    //
+                    // 2. Next best thing is in the videobridge statistics, but
+                    // it feels a bit awkward to put it there. If we want it in
+                    // there, how should it be bubbled up? event driven or have
+                    // it pulled?
+                    //
+                    // Anything else we should be tracking?
+                    incomingBitrateExpirations++;
                 }
                 else if (timeSinceFirstIncomingEstimate > kInitializationTimeMs
                     && input.incomingBitRate > 0L)

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -44,6 +44,8 @@ class AimdRateControl
 
     private static final long kInitializationTimeMs = 5000;
 
+    private static final long kFirstIncomingEstimateExpirationMs = 2 * kInitializationTimeMs;
+
     private static final long kLogIntervalMs = 1000;
 
     private static final long kMaxFeedbackIntervalMs = 1000;
@@ -435,11 +437,26 @@ class AimdRateControl
                 if (input.incomingBitRate > 0L)
                     timeFirstIncomingEstimate = nowMs;
             }
-            else if (nowMs - timeFirstIncomingEstimate > kInitializationTimeMs
-                    && input.incomingBitRate > 0L)
+            else
             {
-                currentBitrateBps = input.incomingBitRate;
-                bitrateIsInitialized = true;
+                long timeSinceFirstIncomingEstimate = nowMs - timeFirstIncomingEstimate;
+                if (timeSinceFirstIncomingEstimate > kFirstIncomingEstimateExpirationMs)
+                {
+                    if (input.incomingBitRate > 0L)
+                    {
+                        timeFirstIncomingEstimate = nowMs;
+                    }
+                    else
+                    {
+                        timeFirstIncomingEstimate = -1L;
+                    }
+                }
+                else if (timeSinceFirstIncomingEstimate > kInitializationTimeMs
+                    && input.incomingBitRate > 0L)
+                {
+                    currentBitrateBps = input.incomingBitRate;
+                    bitrateIsInitialized = true;
+                }
             }
         }
 

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -64,6 +64,9 @@ class AimdRateControl
 
     private boolean bitrateIsInitialized;
 
+    /**
+     * the number of time we've expired the initial incoming estimate.
+     */
     private int incomingBitrateExpirations = 0;
 
     private long currentBitrateBps;
@@ -348,6 +351,14 @@ class AimdRateControl
     }
 
     /**
+     * @return the number of time we've expired the initial incoming estimate.
+     */
+    public int getIncomingEstimateExpirations()
+    {
+        return incomingBitrateExpirations;
+    }
+
+    /**
      * Returns <tt>true</tt> if there is a valid estimate of the incoming
      * bitrate, <tt>false</tt> otherwise.
      *
@@ -453,21 +464,6 @@ class AimdRateControl
                         timeFirstIncomingEstimate = -1L;
                     }
 
-                    // FIXME Where do we want to track the number of incoming
-                    // bitrate expirations (stored in the incomingBitrateExpirations
-                    // variable below)? The sum of this number across all AIMDs/bridges/deployments
-                    // will be the overall number of times we've prevented the ninjas
-                    // problem thanks to this patch. I see a couple of options:
-                    //
-                    // 1. The debug JSON output feels appropriate but that is not
-                    // something that is accessible/plottable in wavefront afaik.
-                    //
-                    // 2. Next best thing is in the videobridge statistics, but
-                    // it feels a bit awkward to put it there. If we want it in
-                    // there, how should it be bubbled up? event driven or have
-                    // it pulled?
-                    //
-                    // Anything else we should be tracking?
                     incomingBitrateExpirations++;
                 }
                 else if (timeSinceFirstIncomingEstimate > kInitializationTimeMs

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -156,6 +156,17 @@ public class RemoteBitrateEstimatorAbsSendTime
     private final Logger logger;
 
     /**
+     * The number of expirations of the initial estimate of the underlying AIMD.
+     *
+     * @return the number of expirations of the initial estimate of the
+     * underlying AIMD.
+     */
+    public int getIncomingEstimateExpirations()
+    {
+        return remoteRate.getIncomingEstimateExpirations();
+    }
+
+    /**
      * Ctor.
      *
      * @param diagnosticContext the {@link DiagnosticContext} of this instance.
@@ -387,12 +398,12 @@ public class RemoteBitrateEstimatorAbsSendTime
         /**
          * Computes the send-time and recv-time deltas to feed to the estimator.
          */
-        private InterArrival interArrival;
+        private final InterArrival interArrival;
 
         /**
          * The Kalman filter implementation that estimates the jitter.
          */
-        private OveruseEstimator estimator;
+        private final OveruseEstimator estimator;
 
         /**
          * The overuse detector that compares the jitter to an adaptive threshold.

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
@@ -110,6 +110,7 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
     override fun getStats(now: Instant): StatisticsSnapshot = StatisticsSnapshot(
         "GoogleCcEstimator", getCurrentBw(now)
     ).apply {
+        addNumber("incomingEstimateExpirations", bitrateEstimatorAbsSendTime.incomingEstimateExpirations)
         addNumber("latestDelayEstimate", sendSideBandwidthEstimation.latestREMB)
         addNumber("latestLossFraction", sendSideBandwidthEstimation.latestFractionLoss / 256.0)
         with(sendSideBandwidthEstimation.statistics) {


### PR DESCRIPTION
We have observed cases where 1-1 calls go through the JVB briefly and
then they switch to p2p mode (as they normally should). The few packets
that go through the bridge are enough to produce a low first incoming
estimate.

Now, when a 3rd participant joins the call (long after the start of the
call) and media is routed through the bridge (as they normally should)
the aimd picks up where it left of with that stale first estimate. The
waiting time to produce a valid estimate (kInitializationTimeMs =
5000ms) is long past and so the aimd promotes that low first incoming
estimate as a valid estimate.

That drives the bitrate controller to suspend videos.

This PR implements a timeout for the first incoming estimate: If the
first incoming estimate is not promoted to a valid estimate in the first
kInitializationTimeMs*2, then we forget it and start over.