### PR TITLE
config: add OveruseDetectorConfig, GoogleCcEstimatorBweConfig. min/max-bw and initial-threshold/overusing-time-threshold are now confgurable via jitsi config.

### DIFF
--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OverUseDetectorOptions.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OverUseDetectorOptions.java
@@ -15,6 +15,8 @@
  */
 package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 
+import org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator.config.OveruseDetectorConfig;
+
 /**
  * Bandwidth over-use detector options.  These are used to drive experimentation
  * with bandwidth estimation parameters.
@@ -36,7 +38,7 @@ class OverUseDetectorOptions
 
     public double initialSlope = 8.0D / 512.0D;
 
-    public double initialThreshold = 25.0D;
+    public double initialThreshold = OveruseDetectorConfig.Companion.getInitialThreshold();
 
     public double initialVarNoise = 50.0D;
 }

--- a/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/main/java/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -18,6 +18,7 @@ package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator;
 import edu.umd.cs.findbugs.annotations.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging.*;
+import org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator.config.OveruseDetectorConfig;
 
 import java.util.*;
 
@@ -46,7 +47,7 @@ class OveruseDetector
 
     private int overuseCounter;
 
-    private static final double overusingTimeThreshold = 100D;
+    private static final double overusingTimeThreshold = OveruseDetectorConfig.Companion.getOverusingTimeThreshold();
 
     private double prevOffset;
 

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
@@ -22,7 +22,6 @@ import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
 import org.jitsi.nlj.util.bps
 import org.jitsi.utils.logging2.createChildLogger
-import org.jitsi.nlj.util.kbps
 import org.jitsi.nlj.util.mbps
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
@@ -30,8 +29,6 @@ import org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator.RemoteBitrate
 import org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation.SendSideBandwidthEstimation
 
 private val defaultInitBw: Bandwidth = 2.5.mbps
-private val defaultMinBw: Bandwidth = 30.kbps
-private val defaultMaxBw: Bandwidth = 20.mbps
 
 class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logger) :
     BandwidthEstimator(diagnosticContext) {
@@ -41,13 +38,13 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
     override var initBw: Bandwidth = defaultInitBw
     /* TODO: observable which sets the components' values if we're in initial state. */
 
-    override var minBw: Bandwidth by Delegates.observable(defaultMinBw) {
+    override var minBw: Bandwidth by Delegates.observable(GoogleCcEstimatorConfig.minBw) {
         _, _, newValue ->
         bitrateEstimatorAbsSendTime.setMinBitrate(newValue.bps.toInt())
         sendSideBandwidthEstimation.setMinMaxBitrate(newValue.bps.toInt(), maxBw.bps.toInt())
     }
 
-    override var maxBw: Bandwidth by Delegates.observable(defaultMaxBw) {
+    override var maxBw: Bandwidth by Delegates.observable(GoogleCcEstimatorConfig.maxBw) {
         _, _, newValue ->
         sendSideBandwidthEstimation.setMinMaxBitrate(minBw.bps.toInt(), newValue.bps.toInt())
     }
@@ -123,8 +120,8 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
 
     override fun reset() {
         initBw = defaultInitBw
-        minBw = defaultMinBw
-        maxBw = defaultMaxBw
+        minBw = GoogleCcEstimatorConfig.minBw
+        maxBw = GoogleCcEstimatorConfig.maxBw
 
         bitrateEstimatorAbsSendTime.reset()
         sendSideBandwidthEstimation.reset(initBw.bps.toLong())

--- a/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimatorConfig.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimatorConfig.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.nlj.rtp.bandwidthestimation
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+import org.jitsi.nlj.util.Bandwidth
+
+class GoogleCcEstimatorConfig {
+    companion object {
+        val minBw: Bandwidth by config {
+            "jmt.bwe.google-cc.min-bw".from(JitsiConfig.newConfig)
+                .convertFrom<String> { Bandwidth.fromString(it) }
+        }
+
+        val maxBw: Bandwidth by config {
+            "jmt.bwe.google-cc.max-bw".from(JitsiConfig.newConfig)
+                .convertFrom<String> { Bandwidth.fromString(it) }
+        }
+    }
+}

--- a/src/main/kotlin/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/config/OveruseDetectorConfig.kt
+++ b/src/main/kotlin/org/jitsi_modified/impl/neomedia/rtp/remotebitrateestimator/config/OveruseDetectorConfig.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi_modified.impl.neomedia.rtp.remotebitrateestimator.config
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+
+class OveruseDetectorConfig {
+    companion object {
+        val initialThreshold: Double by config {
+            "jmt.bwe.overuse-detector.initial-threshold".from(JitsiConfig.newConfig)
+        }
+
+        val overusingTimeThreshold: Double by config {
+            "jmt.bwe.overuse-detector.overusing-time-threshold".from(JitsiConfig.newConfig)
+        }
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,16 @@ jmt {
         probability = 0
       }
     }
+
+    google-cc {
+      min-bw = 30 kbps
+      max-bw = 20 mbps
+    }
+
+    overuse-detector {
+      initial-threshold = 25.0
+      overusing-time-threshold = 100.0
+    }
   }
   dtls {
     // The maximum length of time to wait for a DTLS handshake to complete.


### PR DESCRIPTION
min/max-bw and initial-threshold/overusing-time-threshold are now confgurable via jitsi config.