### PR TITLE
Retain video orientation RTP header extensions

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/RtpExtensions.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/RtpExtensions.kt
@@ -91,7 +91,12 @@ enum class RtpExtensionType(val uri: String) {
     /**
      * The URN which identifies the RTP Header Extension for Video Content Type.
      */
-    VIDEO_CONTENT_TYPE("http://www.webrtc.org/experiments/rtp-hdrext/video-content-type");
+    VIDEO_CONTENT_TYPE("http://www.webrtc.org/experiments/rtp-hdrext/video-content-type"),
+
+    /**
+     * The URN which identifies the RTP Header Extension for Video Orientation.
+     */
+    VIDEO_ORIENTATION("urn:3gpp:video-orientation");
 
     companion object {
         private val uriMap = RtpExtensionType.values().associateBy(RtpExtensionType::uri)

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
@@ -22,7 +22,7 @@ import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.rtp.rtp.RtpPacket
 
 /**
- * Strip all hop-by-hop header extensions.  Currently this leaves only ssrc-audio-level.
+ * Strip all hop-by-hop header extensions.  Currently this leaves only ssrc-audio-level and video-orientation.
  */
 class HeaderExtStripper(
     streamInformationStore: ReadOnlyStreamInformationStore
@@ -30,8 +30,10 @@ class HeaderExtStripper(
     private var retainedExts: Set<Int> = emptySet()
 
     init {
-        streamInformationStore.onRtpExtensionMapping(RtpExtensionType.SSRC_AUDIO_LEVEL) {
-            retainedExts = if (it != null) setOf(it) else emptySet()
+        retainedExtTypes.forEach { rtpExtensionType ->
+            streamInformationStore.onRtpExtensionMapping(rtpExtensionType) {
+                it?.let { retainedExts = retainedExts.plus(it) }
+            }
         }
     }
 
@@ -44,4 +46,10 @@ class HeaderExtStripper(
     }
 
     override fun trace(f: () -> Unit) = f.invoke()
+
+    companion object {
+        private val retainedExtTypes: Set<RtpExtensionType> = setOf(
+            RtpExtensionType.SSRC_AUDIO_LEVEL, RtpExtensionType.VIDEO_ORIENTATION
+        )
+    }
 }


### PR DESCRIPTION
Hello. We use JVB in our project and faced an issue after updating to 2.0.6173. `HeaderExtStripper` drops video-orientation RTP Header Extension and it leads to wrong video orientation for streams coming from mobile devices (that send vertical video from camera). Please consider this fix. Thanks!