### PR TITLE
Set layeringChanged flag when we reset sources after a codec change.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Parser.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Parser.kt
@@ -68,10 +68,6 @@ class Vp9Parser(
                     }
                 }
             }
-
-            /* TODO: we need a way to restore the encoding desc's old layer set if it switches back to some other codec
-             *  (i.e. VP8)
-             */
         }
         if (vp9Packet.spatialLayerIndex > 0 && vp9Packet.isInterPicturePredicted) {
             /* Check if this layer is using K-SVC. */


### PR DESCRIPTION
Fixes issue where VP8 screenshares aren't shown after a VP9->VP8 switch
(e.g. when a Firefox endpoint joins).