### PR TITLE
feat(MediaSourceDesc): add source name

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
@@ -49,7 +49,11 @@ class MediaSourceDesc
      * A string which identifies the owner of this source (e.g. the endpoint
      * which is the sender of the source).
      */
-    val owner: String? = null
+    val owner: String? = null,
+    /**
+     * A string which identifies this source.
+     */
+    val sourceName: String? = null
 ) {
     /**
      * Current single-list view of all the encodings' layers.

--- a/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -28,11 +28,12 @@ class MediaSourceDescTest : ShouldSpec() {
         val ssrcs = arrayOf(0xdeadbeefL, 0xcafebabeL, 0x01234567L)
         val source = createSource(
             ssrcs,
-            1, 3, "Fake owner"
+            1, 3, "Fake owner", "Fake name"
         )
 
         context("Source properties should be correct") {
             source.owner shouldBe "Fake owner"
+            source.sourceName shouldBe "Fake name"
             source.rtpEncodings.size shouldBe 3
 
             source.rtpLayers.size shouldBe 9
@@ -211,7 +212,8 @@ private fun createSource(
     primarySsrcs: Array<Long>,
     numSpatialLayersPerStream: Int,
     numTemporalLayersPerStream: Int,
-    owner: String
+    owner: String,
+    name: String?
 ): MediaSourceDesc {
     var height = 720
 
@@ -226,7 +228,7 @@ private fun createSource(
         ret
     }
 
-    return MediaSourceDesc(encodings, owner)
+    return MediaSourceDesc(encodings, owner, name)
 }
 
 /** A fake rate statistics object, for testing */


### PR DESCRIPTION
The source names are to be used for the multiple streams per endpoint support.