### PR TITLE
feat: add VideoType to MediaSourceDesc

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
+++ b/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
@@ -53,7 +53,11 @@ class MediaSourceDesc
     /**
      * A string which identifies this source.
      */
-    val sourceName: String? = null
+    val sourceName: String? = null,
+    /**
+     * The {@link VideoType} signaled for this media source (defaulting to {@code CAMERA} if nothing has been signaled).
+     */
+    var videoType: VideoType = VideoType.CAMERA,
 ) {
     /**
      * Current single-list view of all the encodings' layers.
@@ -158,7 +162,7 @@ class MediaSourceDesc
      */
     @Synchronized
     fun copy() = MediaSourceDesc(
-        Array(this.rtpEncodings.size) { i -> this.rtpEncodings[i].copy() }, this.owner, this.sourceName
+        Array(this.rtpEncodings.size) { i -> this.rtpEncodings[i].copy() }, this.owner, this.sourceName, this.videoType
     )
 
     override fun toString(): String = buildString {

--- a/src/main/kotlin/org/jitsi/nlj/VideoType.kt
+++ b/src/main/kotlin/org/jitsi/nlj/VideoType.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright @ 2021-Present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.nlj
+
+enum class VideoType {
+    CAMERA,
+    DESKTOP,
+    DESKTOP_HIGH_FPS,
+    NONE
+}

--- a/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -28,12 +28,17 @@ class MediaSourceDescTest : ShouldSpec() {
         val ssrcs = arrayOf(0xdeadbeefL, 0xcafebabeL, 0x01234567L)
         val source = createSource(
             ssrcs,
-            1, 3, "Fake owner", "Fake name"
+            1,
+            3,
+            "Fake owner",
+            "Fake name",
+            VideoType.DESKTOP
         )
 
         context("Source properties should be correct") {
             source.owner shouldBe "Fake owner"
             source.sourceName shouldBe "Fake name"
+            source.videoType shouldBe VideoType.DESKTOP
             source.rtpEncodings.size shouldBe 3
 
             source.rtpLayers.size shouldBe 9
@@ -214,7 +219,8 @@ private fun createSource(
     numSpatialLayersPerStream: Int,
     numTemporalLayersPerStream: Int,
     owner: String,
-    name: String?
+    name: String,
+    videoType: VideoType,
 ): MediaSourceDesc {
     var height = 720
 
@@ -229,7 +235,7 @@ private fun createSource(
         ret
     }
 
-    return MediaSourceDesc(encodings, owner, name)
+    return MediaSourceDesc(encodings, owner, name, videoType)
 }
 
 /** A fake rate statistics object, for testing */


### PR DESCRIPTION
This PR moves the VideoType from the JVB to the JMT, as part of the multiple streams per Endpoint effort. The plan is for an Endpoint to hold references to multiple MediaSourceDesc, where each one will have it's own video type.