### PR TITLE
Fix construction of TCC packets from Instants.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -22,6 +22,7 @@ import org.jitsi.nlj.rtcp.RtcpListener
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.util.ArrayCache
 import org.jitsi.nlj.util.DataSize
+import org.jitsi.nlj.util.instantOfEpochMicro
 import org.jitsi.nlj.util.NEVER
 import org.jitsi.nlj.util.Rfc3711IndexTracker
 import org.jitsi.nlj.util.formatMilli
@@ -105,7 +106,7 @@ class TransportCcEngine(
 
     private fun tccReceived(tccPacket: RtcpFbTccPacket) {
         val now = clock.instant()
-        var currArrivalTimestamp = Instant.ofEpochMilli((tccPacket.GetBaseTimeUs() + 500) / 1000)
+        var currArrivalTimestamp = instantOfEpochMicro(tccPacket.GetBaseTimeUs())
         if (remoteReferenceTime == NEVER) {
             remoteReferenceTime = currArrivalTimestamp
             localReferenceTime = now

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -28,6 +28,7 @@ import org.jitsi.nlj.util.NEVER
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.Rfc3711IndexTracker
 import org.jitsi.nlj.util.bytes
+import org.jitsi.nlj.util.toEpochMicro
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.observableWhenChanged
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -123,12 +124,12 @@ class TccGeneratorNode(
                 mediaSourceSsrc = mediaSsrc,
                 feedbackPacketSeqNum = currTccSeqNum++
             )
-            currentTccPacket.SetBase(windowStartSeq, firstEntry.value.nano / 1000L)
+            currentTccPacket.SetBase(windowStartSeq, firstEntry.value.toEpochMicro())
 
             var nextSequenceNumber = windowStartSeq
             val feedbackBlockPackets = packetArrivalTimes.tailMap(windowStartSeq)
             feedbackBlockPackets.forEach { (seq, timestamp) ->
-                val timestampUs = timestamp.nano / 1000L
+                val timestampUs = timestamp.toEpochMicro()
                 if (!currentTccPacket.AddReceivedPacket(seq, timestampUs)) {
                     tccPackets.add(currentTccPacket.build())
                     currentTccPacket = RtcpFbTccPacketBuilder(

--- a/src/main/kotlin/org/jitsi/nlj/util/ClockUtils.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ClockUtils.kt
@@ -18,9 +18,9 @@
 
 package org.jitsi.nlj.util
 
+import org.jitsi.utils.TimeUtils
 import java.time.Duration
 import java.time.Instant
-import org.jitsi.utils.TimeUtils
 
 @JvmField
 val NEVER: Instant = Instant.MIN
@@ -28,6 +28,47 @@ val NEVER: Instant = Instant.MIN
 fun Instant.formatMilli(): String = TimeUtils.formatTimeAsFullMillis(this.epochSecond, this.nano)
 
 fun Duration.formatMilli(): String = TimeUtils.formatTimeAsFullMillis(this.seconds, this.nano)
+
+/**
+ * Converts this instant to the number of microseconds from the epoch
+ * of 1970-01-01T00:00:00Z.
+ *
+ * If this instant represents a point on the time-line too far in the future
+ * or past to fit in a [Long] microseconds, then an exception is thrown.
+ *
+ * If this instant has greater than microsecond precision, then the conversion
+ * will drop any excess precision information as though the amount in nanoseconds
+ * was subject to integer division by one thousand.
+ *
+ * @return the number of microseconds since the epoch of 1970-01-01T00:00:00Z
+ * @throws ArithmeticException if numeric overflow occurs
+ */
+fun Instant.toEpochMicro(): Long {
+    return if (this.epochSecond < 0 && this.nano > 0) {
+        val micros = Math.multiplyExact(this.epochSecond + 1, 1000_000)
+        val adjustment: Long = (this.nano / 1000 - 1000_000).toLong()
+        Math.addExact(micros, adjustment)
+    } else {
+        val micros = Math.multiplyExact(this.epochSecond, 1000_000)
+        Math.addExact(micros, (this.nano / 1000).toLong())
+    }
+}
+
+/**
+ * Obtains an instance of [Instant] using microseconds from the
+ * epoch of 1970-01-01T00:00:00Z.
+ * <p>
+ * The seconds and nanoseconds are extracted from the specified milliseconds.
+ *
+ * @param epochMicro the number of microseconds from 1970-01-01T00:00:00Z
+ * @return an instant, not null
+ * @throws DateTimeException if the instant exceeds the maximum or minimum instant
+ */
+fun instantOfEpochMicro(epochMicro: Long): Instant {
+    val secs = Math.floorDiv(epochMicro, 1000_000).toLong()
+    val micros = Math.floorMod(epochMicro, 1000_000)
+    return Instant.ofEpochSecond(secs, micros * 1000)
+}
 
 fun <T> Iterable<T>.sumOf(selector: (T) -> Duration): Duration {
     var sum: Duration = Duration.ZERO

--- a/src/main/kotlin/org/jitsi/nlj/util/ClockUtils.kt
+++ b/src/main/kotlin/org/jitsi/nlj/util/ClockUtils.kt
@@ -65,9 +65,9 @@ fun Instant.toEpochMicro(): Long {
  * @throws DateTimeException if the instant exceeds the maximum or minimum instant
  */
 fun instantOfEpochMicro(epochMicro: Long): Instant {
-    val secs = Math.floorDiv(epochMicro, 1000_000).toLong()
+    val secs = Math.floorDiv(epochMicro, 1000_000)
     val micros = Math.floorMod(epochMicro, 1000_000)
-    return Instant.ofEpochSecond(secs, micros * 1000)
+    return Instant.ofEpochSecond(secs, micros * 1000L)
 }
 
 fun <T> Iterable<T>.sumOf(selector: (T) -> Duration): Duration {


### PR DESCRIPTION
Add helper methods to convert Instant to/from microseconds since the epoch.