### PR TITLE
Move routeLoudestOnly filtering.

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/AudioLevelListener.kt
+++ b/src/main/kotlin/org/jitsi/nlj/AudioLevelListener.kt
@@ -17,5 +17,5 @@
 package org.jitsi.nlj
 
 interface AudioLevelListener {
-    fun onLevelReceived(sourceSsrc: Long, level: Long)
+    fun onLevelReceived(sourceSsrc: Long, level: Long): Boolean
 }

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
@@ -65,7 +65,7 @@ interface RtpReceiverEventHandler {
     /**
      * We received an audio level indication from the remote endpoint.
      */
-    fun audioLevelReceived(sourceSsrc: Long, level: Long) {}
+    fun audioLevelReceived(sourceSsrc: Long, level: Long): Boolean = false
     /**
      * The estimation of the available send bandwidth changed.
      */

--- a/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -114,9 +114,8 @@ class RtpReceiverImpl @JvmOverloads constructor(
     private val remoteBandwidthEstimator = RemoteBandwidthEstimator(streamInformationStore, logger, diagnosticContext)
     private val audioLevelReader = AudioLevelReader(streamInformationStore).apply {
         audioLevelListener = object : AudioLevelListener {
-            override fun onLevelReceived(sourceSsrc: Long, level: Long) {
+            override fun onLevelReceived(sourceSsrc: Long, level: Long): Boolean =
                 eventHandler.audioLevelReceived(sourceSsrc, level)
-            }
         }
     }
 


### PR DESCRIPTION
Determine which packets to drop from inside the levelReceived handler.

Doing it at this stage in the pipeline will eliminate the gaps
in RTP sequence numbers that were occurring when packets were dropped.

Added statistic at AudioLevelReader node for packets dropped due to ranking.