### PR TITLE
fix: Fix ConcurentModificationException

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
@@ -37,6 +37,7 @@ import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import java.util.Random
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * [ProbingDataSender] currently supports probing via 2 methods:
@@ -58,7 +59,7 @@ class ProbingDataSender(
     private val logger = createChildLogger(parentLogger)
 
     private var rtxSupported = false
-    private val videoPayloadTypes = mutableSetOf<VideoPayloadType>()
+    private val videoPayloadTypes: MutableSet<VideoPayloadType> = ConcurrentHashMap.newKeySet()
     private var localVideoSsrc: Long? = null
 
     // Stats

--- a/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -20,9 +20,10 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ObserverNode
 import org.jitsi.rtp.rtcp.RtcpPacket
+import java.util.concurrent.ConcurrentHashMap
 
 class SentRtcpStats : ObserverNode("Sent RTCP stats") {
-    private var sentRtcpCounts = mutableMapOf<String, Int>()
+    private var sentRtcpCounts: MutableMap<String, Int> = ConcurrentHashMap()
 
     override fun observe(packetInfo: PacketInfo) {
         val rtcpPacket: RtcpPacket = packetInfo.packetAs()


### PR DESCRIPTION
java.util.ConcurrentModificationException
        at java.base/java.util.HashMap.merge(HashMap.java:1300)
        at org.jitsi.nlj.transform.node.outgoing.SentRtcpStats.observe(SentRtcpStats.kt:29)
        at org.jitsi.nlj.transform.node.ObserverNode.handlePacket(Node.kt:436)
        at org.jitsi.nlj.transform.node.NeverDiscardNode.doProcessPacket(Node.kt:361)
        at org.jitsi.nlj.transform.node.StatsKeepingNode.processPacket(Node.kt:206)
        at org.jitsi.nlj.transform.node.Node.next(Node.kt:107)
        at org.jitsi.nlj.rtcp.KeyframeRequester.doRequestKeyframe(KeyframeRequester.kt:174)
