### PR TITLE
Remove SRTP_AES128_CM_HMAC_SHA1_32 as SRTP cipher

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,8 +40,7 @@ jmt {
     // The DTLS-SRTP protection profiles that are supported, in preference order.
     protection-profiles=[
         "SRTP_AEAD_AES_128_GCM",
-        "SRTP_AES128_CM_HMAC_SHA1_80",
-        "SRTP_AES128_CM_HMAC_SHA1_32"
+        "SRTP_AES128_CM_HMAC_SHA1_80"
     ]
 
     // The engine (cryptographic provider) to use for SRTP cryptography.


### PR DESCRIPTION
Removing SRTP_AES128_CM_HMAC_SHA1_32 from the list of default ciphers. It can still manually get added back into the config if needed.