### PR TITLE
Upgrade to BC 1.70 and fix support for DTLS 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <kotlin.version>1.5.20</kotlin.version>
         <kotest.version>4.6.1</kotest.version>
         <junit.version>5.2.0</junit.version>
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <jitsi.utils.version>1.0-113-g8b75d53</jitsi.utils.version>
         <ktlint.skip>false</ktlint.skip>
         <spotbugs.version>4.0.6</spotbugs.version>

--- a/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
@@ -325,7 +325,7 @@ class DtlsUtils {
                 throw IllegalStateException("error in calculation of seed for export")
             }
 
-            return TlsUtils.PRF(context, masterSecret, asciiLabel, seed, length).extract()
+            return TlsUtils.PRF(sp, masterSecret, asciiLabel, seed, length).extract()
         }
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/dtls/TlsServerImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/TlsServerImpl.kt
@@ -120,7 +120,12 @@ class TlsServerImpl(
             (context.crypto as BcTlsCrypto),
             PrivateKeyFactory.createKey(certificateInfo.keyPair.private.encoded),
             certificateInfo.certificate,
-            SignatureAndHashAlgorithm(HashAlgorithm.sha256, SignatureAlgorithm.ecdsa)
+            /* For DTLS 1.0 support (needed for Jigasi) we can't set this to sha256 fixed */
+            if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(context.clientVersion)) SignatureAndHashAlgorithm(
+                HashAlgorithm.sha256,
+                SignatureAlgorithm.ecdsa
+            )
+            else null
         )
     }
 


### PR DESCRIPTION
- replace deprecated PRF call with current
- only pass SignatureAndHashAlgorithm if supported by other side
- upgrade BouncyCastle from 1.68 to 1.70
