### PR TITLE
DON'T MERGE YET: removed TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA cipher

### DIFF
--- a/src/main/kotlin/org/jitsi/nlj/dtls/TlsClientImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/TlsClientImpl.kt
@@ -132,8 +132,7 @@ class TlsClientImpl(
 
     override fun getCipherSuites(): IntArray {
         return intArrayOf(
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
         )
     }
 

--- a/src/main/kotlin/org/jitsi/nlj/dtls/TlsServerImpl.kt
+++ b/src/main/kotlin/org/jitsi/nlj/dtls/TlsServerImpl.kt
@@ -101,8 +101,7 @@ class TlsServerImpl(
 
     override fun getCipherSuites(): IntArray {
         return intArrayOf(
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
         )
     }
 


### PR DESCRIPTION
This PR removes the last DTLS ciphers which still use SHA1.

I manually verified with Wireshark that TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 successfully gets negotiated with Chrome, Firefox and Jigasi.

Note: don't merge yet as this depends on Jigasi updates in production first.