### PR TITLE
Update jicoco; don't use spyk() for FakeScheduledExecutorService.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jitsi.utils.version>1.0-115-gb93957d</jitsi.utils.version>
         <ktlint.skip>false</ktlint.skip>
         <spotbugs.version>4.6.0</spotbugs.version>
-        <jicoco.version>1.1-108-g737afd1</jicoco.version>
+        <jicoco.version>1.1-110-g42c01d9</jicoco.version>
     </properties>
     <dependencies>
         <dependency>
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
-            <version>1.10.0</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/src/test/kotlin/org/jitsi/nlj/rtcp/StreamPacketRequesterTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtcp/StreamPacketRequesterTest.kt
@@ -21,7 +21,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
-import io.mockk.spyk
 import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.test.concurrent.FakeScheduledExecutorService
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -30,7 +29,7 @@ import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.RtcpFbNackPacket
 class StreamPacketRequesterTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val scheduler: FakeScheduledExecutorService = spyk()
+    private val scheduler = FakeScheduledExecutorService()
 
     private val nackPacketsSent = mutableListOf<RtcpPacket>()
     private fun rtcpSender(rtcpPacket: RtcpPacket) {

--- a/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
+++ b/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
@@ -17,7 +17,6 @@ package org.jitsi.nlj.rtp.bandwidthestimation
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.doubles.shouldBeBetween
-import io.mockk.spyk
 import org.jitsi.test.concurrent.FakeScheduledExecutorService
 import java.time.Clock
 import java.time.Duration
@@ -204,7 +203,7 @@ class PacketReceiver(
 }
 
 class BandwidthEstimationTest : ShouldSpec() {
-    private val scheduler: FakeScheduledExecutorService = spyk()
+    private val scheduler = FakeScheduledExecutorService()
     private val clock: Clock = scheduler.clock
 
     private val ctx = DiagnosticContext(clock)


### PR DESCRIPTION
Makes unit tests substantially faster and use less memory.

Also update mockk.